### PR TITLE
STC-based subtitle edit control implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
             args: -Db_pch=false -Ddefault_library=static --prefix=/usr
           }
           - {
+            name: Ubuntu AppImage,
+            os: ubuntu-latest,
+            buildtype: release,
+            args: -Db_pch=false,
+            appimage: true
+          }
+          - {
             name: macOS x86_64 Debug,
             os: macos-15-intel,
             buildtype: debugoptimized,
@@ -153,6 +160,16 @@ jobs:
             echo "CXX=g++-12" >> "$GITHUB_ENV"
           fi
 
+      - name: Install AppImage tooling
+        if: matrix.config.appimage
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget desktop-file-utils libfuse2
+          wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -O /tmp/linuxdeploy.AppImage
+          chmod +x /tmp/linuxdeploy.AppImage
+          wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /tmp/appimagetool.AppImage
+          chmod +x /tmp/appimagetool.AppImage
+
       - name: Configure
         run: meson setup build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }} ${{ github.ref_type == 'tag' && '-Dofficial_release=true' || '' }}
 
@@ -161,6 +178,59 @@ jobs:
 
       - name: Run test
         run: meson test -C build --verbose "gtest main"
+
+      - name: Generate Ubuntu AppImage
+        if: matrix.config.appimage
+        run: |
+          set -e
+          appdir="$GITHUB_WORKSPACE/appimage"
+          rm -rf "$appdir"
+          mkdir -p "$appdir/usr/bin" "$appdir/usr/share/applications" "$appdir/usr/share/pixmaps"
+
+          cp build/aegisub "$appdir/usr/bin/aegisub"
+          chmod +x "$appdir/usr/bin/aegisub"
+
+          desktop_file=$(find build -name '*.desktop' | head -n 1)
+          if [ -n "$desktop_file" ]; then
+            cp "$desktop_file" "$appdir/usr/share/applications/"
+          fi
+
+          icon_name=$(grep '^Icon=' "$desktop_file" | cut -d= -f2- | tr -d '\r')
+          icon_src=$(find packages/desktop -path '*/aegisub.png' | head -n 1)
+          if [ -n "$icon_src" ]; then
+            for size in 16 22 24 32 48 64 128 256; do
+              mkdir -p "$appdir/usr/share/icons/hicolor/${size}x${size}/apps"
+              cp "$icon_src" "$appdir/usr/share/icons/hicolor/${size}x${size}/apps/${icon_name}.png"
+            done
+            cp "$icon_src" "$appdir/usr/share/pixmaps/${icon_name}.png"
+          fi
+
+          if [ ! -f "$appdir/usr/share/applications"/*.desktop ]; then
+            echo "No desktop file found for AppImage packaging" >&2
+            exit 1
+          fi
+
+          /tmp/linuxdeploy.AppImage --appdir "$appdir" \
+            -e "$appdir/usr/bin/aegisub" \
+            -d "$appdir/usr/share/applications"/*.desktop \
+            -i "$appdir/usr/share/icons/hicolor/256x256/apps/${icon_name}.png" \
+            --output appimage
+
+          appimage_path=$(find . -maxdepth 1 -name '*.AppImage' | head -n 1)
+          if [ -z "$appimage_path" ]; then
+            echo "AppImage was not produced" >&2
+            exit 1
+          fi
+
+          mv "$appimage_path" "Aegisub-Ubuntu.AppImage"
+
+      - name: Upload artifacts - Ubuntu AppImage
+        uses: actions/upload-artifact@v6
+        if: matrix.config.appimage
+        with:
+          name: ${{ matrix.config.name }} - appimage
+          path: Aegisub-Ubuntu.AppImage
+          if-no-files-found: error
 
       # Windows artifacts
       - name: Generate Windows installer

--- a/meson.build
+++ b/meson.build
@@ -419,6 +419,12 @@ if not get_option('csri').disabled() and host_machine.system() == 'windows'
     deps += csri_sp.get_variable('csri_dep')
 endif
 
+if not get_option('wxstc').disabled()
+    conf.set('WITH_WXSTC', 1)
+elif get_option('wxstc').enabled()
+    error('wxstc enabled but wxWidgets stc module not available')
+endif
+
 if cc.has_function('alloca', prefix: '#include <stdlib.h>')
     # The files using alloca() already include <stdlib.h> unconditionally.
 elif cc.has_function('alloca', prefix: '#include <alloca.h>')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,6 +10,7 @@ option('avisynth', type: 'feature', description: 'AviSynth video source')
 
 option('fftw3', type: 'feature', description: 'FFTW3 support')
 option('hunspell', type: 'feature', description: 'Hunspell spell checker')
+option('wxstc', type: 'feature', value: 'enabled', description: 'wxStyledTextCtrl support for syntax highlighting')
 option('uchardet', type: 'feature', description: 'uchardet character encoding detection')
 option('libportal', type: 'feature', description: 'XDG Desktop Portal support through libportal')
 option('csri', type: 'feature', description: 'CSRI support')

--- a/src/auto4_lua.cpp
+++ b/src/auto4_lua.cpp
@@ -384,7 +384,8 @@ namespace {
 
 	int is_editbox_active(lua_State *L)
 	{
-		push_value(L, get_context(L)->textSelectionController->GetControl()->GetSTCFocus());
+		auto *ctrl = get_context(L)->textSelectionController->GetControl();
+		push_value(L, ctrl && ctrl->GetSTCFocus());
 		return 1;
 	}
 

--- a/src/base_grid.cpp
+++ b/src/base_grid.cpp
@@ -58,6 +58,8 @@
 #include <wx/menu.h>
 #include <wx/scrolbar.h>
 #include <wx/sizer.h>
+#include <wx/stc/stc.h>
+#include <wx/textctrl.h>
 
 static bool IsMaskLine(const AssDialogue* d) {
 	const std::string& raw = d->Text.get();

--- a/src/base_grid.cpp
+++ b/src/base_grid.cpp
@@ -101,6 +101,7 @@ BaseGrid::BaseGrid(wxWindow* parent, agi::Context *context)
 	}
 
 	UpdateStyle();
+	SetLayoutDirection(OPT_GET("Subtitle/Grid/RTL Mode")->GetBool() ? wxLayout_RightToLeft : wxLayout_LeftToRight);
 	OnHighlightVisibleChange(*OPT_GET("Subtitle/Grid/Highlight Subtitles in Frame"));
 
 	connections = agi::signal::make_vector({
@@ -133,6 +134,11 @@ BaseGrid::BaseGrid(wxWindow* parent, agi::Context *context)
 
 		OPT_SUB("Subtitle/Grid/Highlight Subtitles in Frame", &BaseGrid::OnHighlightVisibleChange, this),
 		OPT_SUB("Subtitle/Grid/Hide Overrides", [&](agi::OptionValue const&) { Refresh(false); }),
+		OPT_SUB("Subtitle/Grid/RTL Mode", [&](agi::OptionValue const&) {
+			bool new_rtl = OPT_GET("Subtitle/Grid/RTL Mode")->GetBool();
+			SetLayoutDirection(new_rtl ? wxLayout_RightToLeft : wxLayout_LeftToRight);
+			Refresh(false);
+		}),
 	});
 
 	Bind(wxEVT_CONTEXT_MENU, &BaseGrid::OnContextMenu, this);
@@ -284,6 +290,32 @@ void BaseGrid::OnActiveLineChanged(AssDialogue *new_active) {
 		MakeActiveLineVisible();
 
 		extendRow = active_row = new_active->Row;
+
+		// On Ubuntu and macOS, auto-sync grid RTL mode with the active editor.
+		// wxWidgets auto-detects RTL for text controls, so we sync the grid to match.
+#if defined(__WXGTK__) || defined(__WXMAC__)
+		if (context && context->parent) {
+			wxWindow *editor = nullptr;
+			for (wxWindow *win : context->parent->GetChildren()) {
+				if (dynamic_cast<wxTextCtrl*>(win) || dynamic_cast<wxStyledTextCtrl*>(win)) {
+					editor = win;
+					break;
+				}
+			}
+
+			if (editor) {
+				wxLayoutDirection editor_dir = editor->GetLayoutDirection();
+				bool grid_rtl = (GetLayoutDirection() == wxLayout_RightToLeft);
+				bool editor_rtl = (editor_dir == wxLayout_RightToLeft);
+
+				if (editor_rtl != grid_rtl) {
+					OPT_SET("Subtitle/Grid/RTL Mode")->SetBool(editor_rtl);
+					SetLayoutDirection(editor_rtl ? wxLayout_RightToLeft : wxLayout_LeftToRight);
+				}
+			}
+		}
+#endif
+
 		Refresh(false);
 	}
 	else

--- a/src/command/edit.cpp
+++ b/src/command/edit.cpp
@@ -76,6 +76,9 @@
 #include <wx/clipbrd.h>
 #include <wx/fontdlg.h>
 #include <wx/textentry.h>
+#include <wx/textctrl.h>
+#include <wx/stc/stc.h>
+#include <wx/scrolbar.h>
 
 const std::string foldStartMarker = "{:Foldstart}";
 const std::string foldEndMarker = "{:Foldend}";
@@ -1654,6 +1657,8 @@ struct edit_rtl_mode final : public Command {
 	void operator()(agi::Context *c) override {
 		bool current_mode = OPT_GET("Subtitle/Grid/RTL Mode")->GetBool();
 		bool new_mode = !current_mode;
+		
+		// Update config options only - grid and editor rendering will automatically adjust
 		OPT_SET("Subtitle/Grid/RTL Mode")->SetBool(new_mode);
 		OPT_SET("Subtitle/Edit Box/RTL Mode")->SetBool(new_mode);
 	}
@@ -1795,9 +1800,9 @@ namespace cmd {
 		reg(std::make_unique<edit_undo>());
 		reg(std::make_unique<edit_revert>());
 		reg(std::make_unique<edit_insert_original>());
-		reg(std::make_unique<edit_rtl_mode>());
 		reg(std::make_unique<edit_clear>());
 		reg(std::make_unique<edit_clear_text>());
 		reg(std::make_unique<edit_comment>());
+		reg(std::make_unique<edit_rtl_mode>());
 	}
 }

--- a/src/command/edit.cpp
+++ b/src/command/edit.cpp
@@ -1636,6 +1636,29 @@ struct edit_insert_original final : public Command {
 	}
 };
 
+struct edit_rtl_mode final : public Command {
+	CMD_NAME("edit/toggle_rtl_mode")
+	STR_HELP("Toggle between Right-to-Left and Left-to-Right text direction mode for the subtitle grid and editor")
+	CMD_TYPE(COMMAND_VALIDATE | COMMAND_DYNAMIC_NAME)
+
+	wxString StrMenu(const agi::Context *c) const override {
+		bool rtl_mode = OPT_GET("Subtitle/Grid/RTL Mode")->GetBool();
+		return rtl_mode ? _("Switch to &LTR Mode") : _("Switch to &RTL Mode");
+	}
+
+	wxString StrDisplay(const agi::Context *c) const override {
+		bool rtl_mode = OPT_GET("Subtitle/Grid/RTL Mode")->GetBool();
+		return rtl_mode ? _("Switch to LTR Mode") : _("Switch to RTL Mode");
+	}
+
+	void operator()(agi::Context *c) override {
+		bool current_mode = OPT_GET("Subtitle/Grid/RTL Mode")->GetBool();
+		bool new_mode = !current_mode;
+		OPT_SET("Subtitle/Grid/RTL Mode")->SetBool(new_mode);
+		OPT_SET("Subtitle/Edit Box/RTL Mode")->SetBool(new_mode);
+	}
+};
+
 struct edit_line_change_text final : public Command {
 	CMD_NAME("edit/line/change-text")
 	STR_MENU("Change text")
@@ -1772,6 +1795,7 @@ namespace cmd {
 		reg(std::make_unique<edit_undo>());
 		reg(std::make_unique<edit_revert>());
 		reg(std::make_unique<edit_insert_original>());
+		reg(std::make_unique<edit_rtl_mode>());
 		reg(std::make_unique<edit_clear>());
 		reg(std::make_unique<edit_clear_text>());
 		reg(std::make_unique<edit_comment>());

--- a/src/dialog_about.cpp
+++ b/src/dialog_about.cpp
@@ -48,8 +48,10 @@ void ShowAboutDialog(wxWindow *parent) {
 		translatorCredit.clear();
 
 	// Generate about string
+	wxString wxVersionString = wxString::Format("wxWidgets %d.%d.%d", wxMAJOR_VERSION, wxMINOR_VERSION, wxRELEASE_NUMBER);
 	wxString aboutString = wxString("Aegisub ") + GetAegisubShortVersionString() + ".\n"
-		"Copyright (c) 2005-2026 Rodrigo Braz Monteiro, Niels Martin Hansen, Thomas Goyne et al.\n\n"
+		"Copyright (c) 2005-2019 Rodrigo Braz Monteiro, Niels Martin Hansen, Thomas Goyne et al.\n"
+		"Built with " + wxVersionString + ".\n\n"
 		"Programmers:\n"
 		"    Alysson Souza e Silva\n"
 		"    Amar Takhar\n"

--- a/src/dialog_translation.cpp
+++ b/src/dialog_translation.cpp
@@ -35,6 +35,9 @@
 #include "persist_location.h"
 #include "project.h"
 #include "subs_edit_ctrl.h"
+#ifdef WITH_WXSTC
+#include "subs_edit_ctrl_stc.h"
+#endif
 #include "selection_controller.h"
 #include "video_controller.h"
 
@@ -91,52 +94,65 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 	}
 
 	{
-		wxStaticBoxSizer *translated_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Translation"));
+#ifdef WITH_WXSTC
+		bool use_stc = OPT_GET("Subtitle/Use STC")->GetBool();
+		if (use_stc) {
+			translated_text_stc = new SubsStyledTextEditCtrl(this, wxSize(320, 80), 0, nullptr);
+			translated_text_stc->SetWrapMode(wxSTC_WRAP_WORD);
+			translated_text_stc->SetMarginWidth(1, 0);
+			translated_text_stc->SetFocus();
+			translated_text_stc->Bind(wxEVT_CHAR_HOOK, &DialogTranslation::OnKeyDown, this);
+			translated_text_stc->CmdKeyAssign(wxSTC_KEY_RETURN, wxSTC_KEYMOD_SHIFT, wxSTC_CMD_NEWLINE);
 
-		translated_text = new SubsTextEditCtrl(translated_box->GetStaticBox(), wxSize(320, 80), 0, nullptr);
-		translated_text->SetWrapMode(wxSTC_WRAP_WORD);
-		translated_text->SetMarginWidth(1, 0);
-		translated_text->SetFocus();
-		translated_text->Bind(wxEVT_CHAR_HOOK, &DialogTranslation::OnKeyDown, this);
-		translated_text->CmdKeyAssign(wxSTC_KEY_RETURN, wxSTC_KEYMOD_SHIFT, wxSTC_CMD_NEWLINE);
+			wxSizer *translated_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Translation"));
+			translated_box->Add(translated_text_stc, 1, wxEXPAND, 0);
+			translation_sizer->Add(translated_box, 1, wxTOP|wxEXPAND, 5);
+		}
+		else
+#endif
+		{
+			translated_text = new SubsTextEditCtrl(this, wxSize(320, 80), 0, nullptr);
+			translated_text->SetFocus();
+			translated_text->Bind(wxEVT_CHAR_HOOK, &DialogTranslation::OnKeyDown, this);
 
-		translated_box->Add(translated_text, 1, wxEXPAND, 0);
-		translation_sizer->Add(translated_box, 1, wxTOP|wxEXPAND, 5);
+			wxSizer *translated_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Translation"));
+			translated_box->Add(translated_text, 1, wxEXPAND, 0);
+			translation_sizer->Add(translated_box, 1, wxTOP|wxEXPAND, 5);
+		}
 	}
 	main_sizer->Add(translation_sizer, 1, wxALL | wxEXPAND, 5);
 
 	wxSizer *right_box = new wxBoxSizer(wxHORIZONTAL);
 	{
-		wxStaticBoxSizer *hotkey_sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("Keys"));
-		wxWindow *hotkey_sizer_box = hotkey_sizer->GetStaticBox();
+		wxSizer *hotkey_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Keys"));
 
 		wxSizer *hotkey_grid = new wxGridSizer(2, 0, 5);
-		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/commit", _("Accept changes"));
-		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/preview", _("Preview changes"));
-		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/prev", _("Previous line"));
-		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/next", _("Next line"));
-		add_hotkey(hotkey_grid, hotkey_sizer_box, "tool/translation_assistant/insert_original", _("Insert original"));
-		add_hotkey(hotkey_grid, hotkey_sizer_box, "video/play/line", _("Play video"));
-		add_hotkey(hotkey_grid, hotkey_sizer_box, "audio/play/selection", _("Play audio"));
-		add_hotkey(hotkey_grid, hotkey_sizer_box, "edit/line/delete", _("Delete line"));
-		hotkey_sizer->Add(hotkey_grid, 0, wxEXPAND, 0);
+		add_hotkey(hotkey_grid, this, "tool/translation_assistant/commit", _("Accept changes"));
+		add_hotkey(hotkey_grid, this, "tool/translation_assistant/preview", _("Preview changes"));
+		add_hotkey(hotkey_grid, this, "tool/translation_assistant/prev", _("Previous line"));
+		add_hotkey(hotkey_grid, this, "tool/translation_assistant/next", _("Next line"));
+		add_hotkey(hotkey_grid, this, "tool/translation_assistant/insert_original", _("Insert original"));
+		add_hotkey(hotkey_grid, this, "video/play/line", _("Play video"));
+		add_hotkey(hotkey_grid, this, "audio/play/selection", _("Play audio"));
+		add_hotkey(hotkey_grid, this, "edit/line/delete", _("Delete line"));
+		hotkey_box->Add(hotkey_grid, 0, wxEXPAND, 0);
 
-		seek_video = new wxCheckBox(hotkey_sizer_box, -1, _("Enable &preview"));
+		seek_video = new wxCheckBox(this, -1, _("Enable &preview"));
 		seek_video->SetValue(true);
-		hotkey_sizer->Add(seek_video, 0, wxTOP, 5);
+		hotkey_box->Add(seek_video, 0, wxTOP, 5);
 
-		right_box->Add(hotkey_sizer, 1, wxRIGHT | wxEXPAND, 5);
+		right_box->Add(hotkey_box, 1, wxRIGHT | wxEXPAND, 5);
 	}
 
 	{
 		wxStaticBoxSizer *actions_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Actions"));
 
-		wxButton *play_audio = new wxButton(actions_box->GetStaticBox(), -1, _("Play &Audio"));
+		wxButton *play_audio = new wxButton(this, -1, _("Play &Audio"));
 		play_audio->Enable(!!c->project->AudioProvider());
 		play_audio->Bind(wxEVT_BUTTON, &DialogTranslation::OnPlayAudioButton, this);
 		actions_box->Add(play_audio, 0, wxALL, 5);
 
-		wxButton *play_video = new wxButton(actions_box->GetStaticBox(), -1, _("Play &Video"));
+		wxButton *play_video = new wxButton(this, -1, _("Play &Video"));
 		play_video->Enable(!!c->project->VideoProvider());
 		play_video->Bind(wxEVT_BUTTON, &DialogTranslation::OnPlayVideoButton, this);
 		actions_box->Add(play_video, 0, wxLEFT | wxRIGHT | wxBOTTOM, 5);
@@ -260,12 +276,29 @@ void DialogTranslation::UpdateDisplay() {
 
 	if (seek_video->IsChecked()) c->videoController->JumpToTime(active_line->Start);
 
-	translated_text->ClearAll();
-	translated_text->SetFocus();
+	// Clear and focus the appropriate control
+#ifdef WITH_WXSTC
+	if (OPT_GET("Subtitle/Use STC")->GetBool()) {
+		translated_text_stc->ClearAll();
+		translated_text_stc->SetFocus();
+	}
+	else {
+#endif
+		translated_text->Clear();
+		translated_text->SetFocus();
+#ifdef WITH_WXSTC
+	}
+#endif
 }
 
 void DialogTranslation::Commit(bool next) {
-	std::string new_value = translated_text->GetTextRaw().data();
+	std::string new_value;
+#ifdef WITH_WXSTC
+	if (OPT_GET("Subtitle/Use STC")->GetBool())
+		new_value = translated_text_stc->GetTextRaw().data();
+	else
+#endif
+		new_value = translated_text->GetValue().utf8_str();
 	boost::replace_all(new_value, "\r\n", "\\N");
 	boost::replace_all(new_value, "\r", "\\N");
 	boost::replace_all(new_value, "\n", "\\N");
@@ -289,7 +322,12 @@ void DialogTranslation::Commit(bool next) {
 
 void DialogTranslation::InsertOriginal() {
 	auto const& text = blocks[cur_block]->GetText();
-	translated_text->AddTextRaw(text.data(), text.size());
+#ifdef WITH_WXSTC
+	if (OPT_GET("Subtitle/Use STC")->GetBool())
+		translated_text_stc->AddTextRaw(text.data(), text.size());
+	else
+#endif
+		translated_text->AppendText(to_wx(text));
 }
 
 void DialogTranslation::OnKeyDown(wxKeyEvent &evt) {
@@ -298,7 +336,12 @@ void DialogTranslation::OnKeyDown(wxKeyEvent &evt) {
 
 void DialogTranslation::OnPlayVideoButton(wxCommandEvent &) {
 	c->videoController->PlayLine();
-	translated_text->SetFocus();
+#ifdef WITH_WXSTC
+	if (OPT_GET("Subtitle/Use STC")->GetBool())
+		translated_text_stc->SetFocus();
+	else
+#endif
+		translated_text->SetFocus();
 }
 
 void DialogTranslation::OnPlayAudioButton(wxCommandEvent &) {

--- a/src/dialog_translation.h
+++ b/src/dialog_translation.h
@@ -26,6 +26,7 @@ class AssDialogue;
 class AssDialogueBlock;
 class PersistLocation;
 class SubsTextEditCtrl;
+class SubsStyledTextEditCtrl;
 class wxCheckBox;
 class wxStaticText;
 class wxStyledTextCtrl;
@@ -52,7 +53,11 @@ class DialogTranslation final : public wxDialog {
 
 	wxStaticText *line_number_display;
 	wxStyledTextCtrl *original_text;
-	SubsTextEditCtrl *translated_text;
+    
+	#ifdef WITH_WXSTC
+		SubsStyledTextEditCtrl *translated_text_stc;
+	#endif
+		SubsTextEditCtrl *translated_text;
 	wxCheckBox *seek_video;
 
 	std::unique_ptr<PersistLocation> persist;

--- a/src/grid_column.cpp
+++ b/src/grid_column.cpp
@@ -394,16 +394,21 @@ public:
 
 class GridColumnText final : public GridColumn {
 	const agi::OptionValue *override_mode;
+	const agi::OptionValue *rtl_mode;
 	wxString replace_char;
 
 	agi::signal::Connection replace_char_connection;
+	agi::signal::Connection rtl_mode_connection;
 
 public:
 	GridColumnText()
 	: override_mode(OPT_GET("Subtitle/Grid/Hide Overrides"))
+	, rtl_mode(OPT_GET("Subtitle/Grid/RTL Mode"))
 	, replace_char(to_wx(OPT_GET("Subtitle/Grid/Hide Overrides Char")->GetString()))
 	, replace_char_connection(OPT_SUB("Subtitle/Grid/Hide Overrides Char",
 		[&](agi::OptionValue const& v) { replace_char = to_wx(v.GetString()); }))
+	, rtl_mode_connection(OPT_SUB("Subtitle/Grid/RTL Mode",
+		[](agi::OptionValue const&) { /* RTL mode changed, grid will refresh */ }))
 	{
 	}
 

--- a/src/libresrc/default_config.json
+++ b/src/libresrc/default_config.json
@@ -386,7 +386,6 @@
 	},
 
 	"Subtitle" : {
-		"Use STC" : false,
 		"Character Counter" : {
 			"Ignore Whitespace" : true,
 			"Ignore Punctuation" : true,
@@ -424,7 +423,8 @@
 		"Show Original": false,
 		"Time Edit" : {
 			"Insert Mode" : true
-		}
+		},
+		"Use STC" : true
 	},
 
 	"Subtitle Format" : {

--- a/src/libresrc/default_config.json
+++ b/src/libresrc/default_config.json
@@ -386,6 +386,7 @@
 	},
 
 	"Subtitle" : {
+		"Use STC" : false,
 		"Character Counter" : {
 			"Ignore Whitespace" : true,
 			"Ignore Punctuation" : true,
@@ -401,7 +402,8 @@
 		"Edit Box" : {
 			"Soft Line Break": false,
 			"Font Face" : "",
-			"Font Size" : 10
+			"Font Size" : 10,
+			"RTL Mode" : false
 		},
 		"Grid" : {
 			"Column" : [
@@ -412,7 +414,8 @@
 			"Font Size" : 9,
 			"Hide Overrides" : 1,
 			"Hide Overrides Char" : "☀",
-			"Highlight Subtitles in Frame" : true
+			"Highlight Subtitles in Frame" : true,
+			"RTL Mode" : false
 		},
 		"Highlight" : {
 			"Syntax" : true

--- a/src/libresrc/default_menu.json
+++ b/src/libresrc/default_menu.json
@@ -42,7 +42,21 @@
     ],
     "main" : "[Dummy, set in platform configs]",
     "main/file" : "[Dummy, set in platform configs]",
-    "main/edit" : "[Dummy, set in platform configs]",
+    "main/edit" : [
+        { "command" : "edit/undo" },
+        { "command" : "edit/redo" },
+        {},
+        { "command" : "edit/line/cut" },
+        { "command" : "edit/line/copy" },
+        { "command" : "edit/line/paste" },
+        { "command" : "edit/line/paste/over" },
+        {},
+        { "command" : "subtitle/find" },
+        { "command" : "subtitle/find/next" },
+        { "command" : "edit/find_replace" },
+        {},
+        { "command" : "edit/toggle_rtl_mode" }
+    ],
     "main/subtitle" : "[Dummy, set in platform configs]",
     "main/subtitle/insert lines" : [
         { "command" : "subtitle/insert/before" },

--- a/src/libresrc/default_menu_platform.json
+++ b/src/libresrc/default_menu_platform.json
@@ -45,7 +45,9 @@
         { "command" : "subtitle/find" },
         { "command" : "subtitle/find/next" },
         { "command" : "edit/find_replace" },
-        { "command" : "edit/find_in_folder" }
+        { "command" : "edit/find_in_folder" },
+        {},
+        { "command" : "edit/toggle_rtl_mode" }
     ],
     "main/ai" : [
         { "command" : "ai/proofread" },

--- a/src/libresrc/osx/default_config.json
+++ b/src/libresrc/osx/default_config.json
@@ -11,6 +11,7 @@
         "Grid" : {
             "Font Face" : "",
             "Font Size" : 12
-        }
+        },
+		"Use STC" : true
     }
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -131,6 +131,13 @@ aegisub_src = files(
     'subs_controller.cpp',
     'subs_edit_box.cpp',
     'subs_edit_ctrl.cpp',
+)
+
+if conf.has('WITH_WXSTC')
+    aegisub_src += files('subs_edit_ctrl_stc.cpp')
+endif
+
+aegisub_src += files(
     'subs_preview.cpp',
     'subtitle_format.cpp',
     'subtitle_format_ass.cpp',
@@ -190,10 +197,6 @@ aegisub_src = files(
 	'visual_tool_textbox.cpp',
     'visual_tool_vector_clip.cpp',
 )
-
-if conf.has('WITH_WXSTC')
-    aegisub_src += files('subs_edit_ctrl_stc.cpp')
-endif
 
 if host_machine.system() == 'darwin'
     aegisub_src += files(

--- a/src/meson.build
+++ b/src/meson.build
@@ -191,6 +191,10 @@ aegisub_src = files(
     'visual_tool_vector_clip.cpp',
 )
 
+if conf.has('WITH_WXSTC')
+    aegisub_src += files('subs_edit_ctrl_stc.cpp')
+endif
+
 if host_machine.system() == 'darwin'
     aegisub_src += files(
         'font_file_lister_coretext.mm',

--- a/src/meson.build
+++ b/src/meson.build
@@ -203,6 +203,10 @@ if host_machine.system() == 'darwin'
         'font_file_lister_coretext.mm',
         'osx/osx_utils.mm',
     )
+
+    if conf.has('WITH_WXSTC')
+        aegisub_src += files('osx/scintilla_ime.mm')
+    endif
 elif host_machine.system() == 'windows'
     aegisub_src += files(
         'avisynth_wrap.cpp',

--- a/src/osx/scintilla_ime.h
+++ b/src/osx/scintilla_ime.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <wx/fwd.h>
-
 class wxKeyEvent;
 class wxStyledTextCtrl;
 

--- a/src/osx/scintilla_ime.h
+++ b/src/osx/scintilla_ime.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2014, Thomas Goyne <plorkyeran@aegisub.org>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR THIS SOFTWARE.
+//
+// Aegisub Project http://www.aegisub.org/
+
+#pragma once
+
+#include <wx/fwd.h>
+
+class wxKeyEvent;
+class wxStyledTextCtrl;
+
+namespace osx {
+namespace ime {
+	/// Initialize IME support for a Scintilla text control
+	void inject(wxStyledTextCtrl *ctrl);
+
+	/// Clean up IME support for a Scintilla text control
+	void invalidate(wxStyledTextCtrl *ctrl);
+
+	/// Process a key event through the IME system
+	/// Returns true if the event was handled by the IME
+	bool process_key_event(wxStyledTextCtrl *ctrl, wxKeyEvent &evt);
+}
+}

--- a/src/osx/scintilla_ime.mm
+++ b/src/osx/scintilla_ime.mm
@@ -1,0 +1,207 @@
+// Copyright (c) 2014, Thomas Goyne <plorkyeran@aegisub.org>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+// Aegisub Project http://www.aegisub.org/
+
+#import <objc/runtime.h>
+#import <wx/osx/private.h>
+#import <wx/stc/stc.h>
+
+// from src/osx/cocoa/window.mm
+@interface wxNSView : NSView <NSTextInputClient> { }
+@end
+
+@interface IMEState : NSObject
+@property (nonatomic) NSRange markedRange;
+@property (nonatomic) bool undoActive;
+@end
+
+@implementation IMEState
+- (id)init {
+    self = [super init];
+    self.markedRange = NSMakeRange(NSNotFound, 0);
+    self.undoActive = false;
+    return self;
+}
+@end
+
+@interface ScintillaNSView : wxNSView <NSTextInputClient>
+@property (nonatomic, readonly) wxStyledTextCtrl *stc;
+@property (nonatomic, readonly) IMEState *state;
+@end
+
+@implementation ScintillaNSView
+- (Class)superclass {
+    return [wxNSView superclass];
+}
+
+- (wxStyledTextCtrl *)stc {
+    return static_cast<wxStyledTextCtrl *>(wxWidgetImpl::FindFromWXWidget(self)->GetWXPeer());
+}
+
+- (IMEState *)state {
+    return objc_getAssociatedObject(self, [IMEState class]);
+}
+
+- (void)invalidate {
+    self.state.markedRange = NSMakeRange(NSNotFound, 0);
+    [self.inputContext discardMarkedText];
+}
+
+#pragma mark - NSTextInputClient
+
+- (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)aRange
+                                                actualRange:(NSRangePointer)actualRange
+{
+    return nil;
+}
+
+- (NSUInteger)characterIndexForPoint:(NSPoint)point {
+    return self.stc->PositionFromPoint(wxPoint(point.x, point.y));
+}
+
+- (BOOL)drawsVerticallyForCharacterAtIndex:(NSUInteger)charIndex {
+    return NO;
+}
+
+- (NSRect)firstRectForCharacterRange:(NSRange)range
+                         actualRange:(NSRangePointer)actualRange
+{
+    auto stc = self.stc;
+    int line = stc->LineFromPosition(range.location);
+    int height = stc->TextHeight(line);
+    auto pt = stc->PointFromPosition(range.location);
+
+    int width = 0;
+    if (range.length > 0) {
+        // If the end of the range is on the next line, the range should be
+        // truncated to the current line and actualRange should be set to the
+        // truncated range
+        int end_line = stc->LineFromPosition(range.location + range.length);
+        if (end_line > line) {
+            range.length = stc->PositionFromLine(line + 1) - 1 - range.location;
+            *actualRange = range;
+        }
+
+        auto end_pt = stc->PointFromPosition(range.location + range.length);
+        width = end_pt.x - pt.x;
+    }
+
+    auto rect = NSMakeRect(pt.x, pt.y, width, height);
+    rect = [self convertRect:rect toView:nil];
+    return [self.window convertRectToScreen:rect];
+}
+
+- (BOOL)hasMarkedText {
+    return self.state.markedRange.length > 0;
+}
+
+- (void)insertText:(id)str replacementRange:(NSRange)replacementRange {
+    [self unmarkText];
+    [super insertText:str replacementRange:replacementRange];
+}
+
+- (NSRange)markedRange {
+    return self.state.markedRange;
+}
+
+- (NSRange)selectedRange {
+    long from = 0, to = 0;
+    self.stc->GetSelection(&from, &to);
+    return NSMakeRange(from, to - from);
+}
+
+- (void)setMarkedText:(id)str
+        selectedRange:(NSRange)range
+     replacementRange:(NSRange)replacementRange
+{
+    if ([str isKindOfClass:[NSAttributedString class]])
+        str = [str string];
+
+    auto stc = self.stc;
+    auto state = self.state;
+
+    int pos = stc->GetInsertionPoint();
+    if (state.markedRange.length > 0) {
+        pos = state.markedRange.location;
+        stc->DeleteRange(pos, state.markedRange.length);
+        stc->SetSelection(pos, pos);
+    } else {
+        state.undoActive = stc->GetUndoCollection();
+        if (state.undoActive)
+            stc->SetUndoCollection(false);
+    }
+
+    auto utf8 = [str UTF8String];
+    auto utf8len = strlen(utf8);
+    stc->AddTextRaw(utf8, utf8len);
+
+    state.markedRange = NSMakeRange(pos, utf8len);
+
+    stc->SetIndicatorCurrent(1);
+    stc->IndicatorFillRange(pos, utf8len);
+
+    // Re-enable undo if we got a zero-length string as that means we're done
+    if (!utf8len && state.undoActive)
+        stc->SetUndoCollection(true);
+    else {
+        int start = pos;
+        // Range is in utf-16 code units
+        if (range.location > 0)
+            start += [[str substringToIndex:range.location] lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+        int length = [[str substringWithRange:range] lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+        stc->SetSelection(start, start + length);
+    }
+}
+
+- (void)unmarkText {
+    auto state = self.state;
+    if (state.markedRange.length > 0) {
+        self.stc->DeleteRange(state.markedRange.location, state.markedRange.length);
+        state.markedRange = NSMakeRange(NSNotFound, 0);
+        if (state.undoActive)
+            self.stc->SetUndoCollection(true);
+    }
+}
+
+- (NSArray *)validAttributesForMarkedText {
+    return @[];
+}
+@end
+
+namespace osx { namespace ime {
+void inject(wxStyledTextCtrl *ctrl) {
+    id view = (id)ctrl->GetHandle();
+    object_setClass(view, [ScintillaNSView class]);
+
+    auto state = [IMEState new];
+    objc_setAssociatedObject(view, [IMEState class], state,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [state release];
+}
+
+void invalidate(wxStyledTextCtrl *ctrl) {
+    [(ScintillaNSView *)ctrl->GetHandle() invalidate];
+}
+
+bool process_key_event(wxStyledTextCtrl *ctrl, wxKeyEvent &evt) {
+    if (evt.GetModifiers() != 0) return false;
+    if (evt.GetKeyCode() != WXK_RETURN && evt.GetKeyCode() != WXK_TAB) return false;
+    if (![(ScintillaNSView *)ctrl->GetHandle() hasMarkedText]) return false;
+
+    evt.Skip();
+    return true;
+}
+
+} }

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -226,7 +226,9 @@ void Interface(wxTreebook *book, Preferences *parent) {
 	auto p = new OptionPage(book, parent, _("Interface"));
 
 	auto edit_box = p->PageSizer(_("Edit Box"));
+	p->OptionAdd(edit_box, _("Use styled edit box"), "Subtitle/Use STC");
 	p->OptionAdd(edit_box, _("Enable call tips"), "App/Call Tips");
+	p->OptionAdd(edit_box, _("Enable RTL mode for Edit Box"), "Subtitle/Edit Box/RTL Mode");
 	p->OptionAdd(edit_box, _("Overwrite in time boxes"), "Subtitle/Time Edit/Insert Mode");
 	p->OptionAdd(edit_box, _("Shift+Enter adds \\n"), "Subtitle/Edit Box/Soft Line Break");
 	p->OptionAdd(edit_box, _("Enable syntax highlighting"), "Subtitle/Highlight/Syntax");
@@ -244,6 +246,7 @@ void Interface(wxTreebook *book, Preferences *parent) {
 	p->OptionAdd(grid, _("Focus grid on click"), "Subtitle/Grid/Focus Allow");
 	p->OptionAdd(grid, _("Highlight visible subtitles"), "Subtitle/Grid/Highlight Subtitles in Frame");
 	p->OptionAdd(grid, _("Hide overrides symbol"), "Subtitle/Grid/Hide Overrides Char");
+	p->OptionAdd(grid, _("Enable RTL mode for Grid"), "Subtitle/Grid/RTL Mode");
 	p->OptionFont(grid, "Subtitle/Grid/");
 
 	auto tl_assistant = p->PageSizer(_("Translation Assistant"));

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -228,7 +228,6 @@ void Interface(wxTreebook *book, Preferences *parent) {
 	auto edit_box = p->PageSizer(_("Edit Box"));
 	p->OptionAdd(edit_box, _("Use styled edit box"), "Subtitle/Use STC");
 	p->OptionAdd(edit_box, _("Enable call tips"), "App/Call Tips");
-	p->OptionAdd(edit_box, _("Enable RTL mode for Edit Box"), "Subtitle/Edit Box/RTL Mode");
 	p->OptionAdd(edit_box, _("Overwrite in time boxes"), "Subtitle/Time Edit/Insert Mode");
 	p->OptionAdd(edit_box, _("Shift+Enter adds \\n"), "Subtitle/Edit Box/Soft Line Break");
 	p->OptionAdd(edit_box, _("Enable syntax highlighting"), "Subtitle/Highlight/Syntax");
@@ -246,7 +245,6 @@ void Interface(wxTreebook *book, Preferences *parent) {
 	p->OptionAdd(grid, _("Focus grid on click"), "Subtitle/Grid/Focus Allow");
 	p->OptionAdd(grid, _("Highlight visible subtitles"), "Subtitle/Grid/Highlight Subtitles in Frame");
 	p->OptionAdd(grid, _("Hide overrides symbol"), "Subtitle/Grid/Hide Overrides Char");
-	p->OptionAdd(grid, _("Enable RTL mode for Grid"), "Subtitle/Grid/RTL Mode");
 	p->OptionFont(grid, "Subtitle/Grid/");
 
 	auto tl_assistant = p->PageSizer(_("Translation Assistant"));

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -50,6 +50,9 @@
 #include "project.h"
 #include "selection_controller.h"
 #include "subs_edit_ctrl.h"
+#ifdef WITH_WXSTC
+#include "subs_edit_ctrl_stc.h"
+#endif
 #include "text_selection_controller.h"
 #include "timeedit_ctrl.h"
 #include "tooltip_manager.h"
@@ -210,8 +213,34 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	main_sizer->Add(middle_right_sizer,0,wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,3);
 
 	// Text editor
-	edit_ctrl = new SubsTextEditCtrl(this, FromDIP(wxSize(300,50)), (OPT_GET("App/Dark Mode")->GetBool() ? wxBORDER_SIMPLE : wxBORDER_SUNKEN), c);
-	edit_ctrl->Bind(wxEVT_CHAR_HOOK, &SubsEditBox::OnKeyDown, this);
+#ifdef WITH_WXSTC
+	if (use_stc) {
+		edit_ctrl_stc = new SubsStyledTextEditCtrl(this, FromDIP(wxSize(300,50)), (OPT_GET("App/Dark Mode")->GetBool() ? wxBORDER_SIMPLE : wxBORDER_SUNKEN), c);
+		edit_ctrl_stc->Bind(wxEVT_CHAR_HOOK, &SubsEditBox::OnKeyDown, this);
+		edit_ctrl_stc->SetInitialSize(FromDIP(wxSize(300,50)));
+		main_sizer->Add(edit_ctrl_stc, wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, 3));
+		edit_ctrl_stc->Bind(wxEVT_STC_MODIFIED, &SubsEditBox::OnChangeStc, this);
+		edit_ctrl_stc->SetModEventMask(wxSTC_MOD_INSERTTEXT | wxSTC_MOD_DELETETEXT | wxSTC_STARTACTION);
+		context->textSelectionController->SetControl(edit_ctrl_stc);
+		edit_ctrl_stc->SetFocus();
+	} else {
+		edit_ctrl_tc = new SubsTextEditCtrl(this, FromDIP(wxSize(300,50)), (OPT_GET("App/Dark Mode")->GetBool() ? wxBORDER_SIMPLE : wxBORDER_SUNKEN), c);
+		edit_ctrl_tc->Bind(wxEVT_CHAR_HOOK, &SubsEditBox::OnKeyDown, this);
+		edit_ctrl_tc->SetInitialSize(FromDIP(wxSize(300,50)));
+		main_sizer->Add(edit_ctrl_tc, wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, 3));
+		edit_ctrl_tc->Bind(wxEVT_TEXT, &SubsEditBox::OnChangeTc, this);
+		context->textSelectionController->SetControl(edit_ctrl_tc);
+		edit_ctrl_tc->SetFocus();
+	}
+#else
+	edit_ctrl_tc = new SubsTextEditCtrl(this, FromDIP(wxSize(300,50)), (OPT_GET("App/Dark Mode")->GetBool() ? wxBORDER_SIMPLE : wxBORDER_SUNKEN), c);
+	edit_ctrl_tc->Bind(wxEVT_CHAR_HOOK, &SubsEditBox::OnKeyDown, this);
+	edit_ctrl_tc->SetInitialSize(FromDIP(wxSize(300,50)));
+	main_sizer->Add(edit_ctrl_tc, wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, 3));
+	edit_ctrl_tc->Bind(wxEVT_TEXT, &SubsEditBox::OnChangeTc, this);
+	context->textSelectionController->SetControl(edit_ctrl_tc);
+	edit_ctrl_tc->SetFocus();
+#endif
 
 	secondary_editor = new wxTextCtrl(this, -1, "", wxDefaultPosition, FromDIP(wxSize(300,50)), (OPT_GET("App/Dark Mode")->GetBool() ? wxBORDER_SIMPLE : wxBORDER_SUNKEN) | wxTE_MULTILINE | wxTE_READONLY);
 	souceline_editor = new wxTextCtrl(this, -1, "", wxDefaultPosition, FromDIP(wxSize(300,50)), (OPT_GET("App/Dark Mode")->GetBool() ? wxBORDER_SIMPLE : wxBORDER_SUNKEN) | wxTE_MULTILINE | wxTE_READONLY);
@@ -236,9 +265,6 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	main_sizer->Hide(bottom_sizer);
 
 	SetSizerAndFit(main_sizer);
-
-	edit_ctrl->Bind(wxEVT_STC_MODIFIED, &SubsEditBox::OnChange, this);
-	edit_ctrl->SetModEventMask(wxSTC_MOD_INSERTTEXT | wxSTC_MOD_DELETETEXT | wxSTC_STARTACTION);
 
 	Bind(wxEVT_TEXT, &SubsEditBox::OnLayerEnter, this, layer->GetId());
 	Bind(wxEVT_SPINCTRL, &SubsEditBox::OnLayerEnter, this, layer->GetId());
@@ -270,7 +296,13 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 }
 
 SubsEditBox::~SubsEditBox() {
-	c->textSelectionController->SetControl(nullptr);
+	// Disambiguate nullptr for overloaded SetControl by casting to the
+	// specific control pointer types. Call both to ensure any bound control
+	// is cleared regardless of which overload was used to set it.
+#ifdef WITH_WXSTC
+	c->textSelectionController->SetControl(static_cast<wxStyledTextCtrl*>(nullptr));
+#endif
+	c->textSelectionController->SetControl(static_cast<wxTextCtrl*>(nullptr));
 }
 
 wxTextCtrl *SubsEditBox::MakeMarginCtrl(wxString const& tooltip, int margin, wxString const& commit_msg) {
@@ -372,7 +404,14 @@ void SubsEditBox::UpdateFields(int type, bool repopulate_lists) {
 	}
 
 	if (type & AssFile::COMMIT_DIAG_TEXT) {
-		edit_ctrl->SetTextTo(line->Text);
+#ifdef WITH_WXSTC
+		if (use_stc && edit_ctrl_stc) {
+			edit_ctrl_stc->SetTextTo(line->Text);
+		} else
+#endif
+		if (edit_ctrl_tc) {
+			edit_ctrl_tc->SetValue(to_wx(line->Text));
+		}
 		souceline_editor->SetValue(to_wx(line->SourceLineText));
 		UpdateCharacterCount(line->Text);
 	}
@@ -459,10 +498,20 @@ void SubsEditBox::OnKeyDown(wxKeyEvent &event) {
 	hotkey::check("Subtitle Edit Box", c, event);
 }
 
-void SubsEditBox::OnChange(wxStyledTextEvent &event) {
-	if (line && edit_ctrl->GetTextRaw().data() != line->Text.get()) {
+#ifdef WITH_WXSTC
+void SubsEditBox::OnChangeStc(wxStyledTextEvent &event) {
+	if (line && edit_ctrl_stc->GetTextRaw().data() != line->Text.get()) {
 		if (event.GetModificationType() & wxSTC_STARTACTION)
 			commit_id = -1;
+		CommitText(_("modify text"));
+		UpdateCharacterCount(line->Text);
+	}
+}
+#endif
+
+void SubsEditBox::OnChangeTc(wxCommandEvent& event) {
+	if (line && from_wx(edit_ctrl_tc->GetValue()) != line->Text.get()) {
+		commit_id = -1;
 		CommitText(_("modify text"));
 		UpdateCharacterCount(line->Text);
 	}
@@ -497,8 +546,15 @@ void SubsEditBox::SetSelectedRows(T AssDialogueBase::*field, wxString const& val
 }
 
 void SubsEditBox::CommitText(wxString const& desc) {
-	auto data = edit_ctrl->GetTextRaw();
-	SetSelectedRows(&AssDialogue::Text, boost::flyweight<std::string>(data.data(), data.length()), desc, AssFile::COMMIT_DIAG_TEXT, true);
+#ifdef WITH_WXSTC
+	if (use_stc && edit_ctrl_stc) {
+		auto data = edit_ctrl_stc->GetTextRaw();
+		SetSelectedRows(&AssDialogue::Text, boost::flyweight<std::string>(data.data(), data.length()), desc, AssFile::COMMIT_DIAG_TEXT, true);
+	} else
+#endif
+	if (edit_ctrl_tc) {
+		SetSelectedRows(&AssDialogue::Text, edit_ctrl_tc->GetValue(), desc, AssFile::COMMIT_DIAG_TEXT, true);
+	}
 }
 
 void SubsEditBox::CommitTimes(TimeField field) {
@@ -597,7 +653,14 @@ void SubsEditBox::SetControlsState(bool state) {
 	Enable(state);
 	if (!state) {
 		wxEventBlocker blocker(this);
-		edit_ctrl->SetTextTo("");
+#ifdef WITH_WXSTC
+		if (use_stc && edit_ctrl_stc) {
+			edit_ctrl_stc->SetTextTo("");
+		} else
+#endif
+		if (edit_ctrl_tc) {
+			edit_ctrl_tc->SetValue("");
+		}
 	}
 }
 
@@ -676,7 +739,14 @@ void SubsEditBox::OnCommentChange(wxCommandEvent &evt) {
 
 void SubsEditBox::CallCommand(const char *cmd_name) {
 	cmd::call(cmd_name, c);
-	edit_ctrl->SetFocus();
+#ifdef WITH_WXSTC
+	if (use_stc && edit_ctrl_stc) {
+		edit_ctrl_stc->SetFocus();
+	} else
+#endif
+	if (edit_ctrl_tc) {
+		edit_ctrl_tc->SetFocus();
+	}
 }
 
 void SubsEditBox::UpdateCharacterCount(std::string const& text) {

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -287,12 +287,6 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 		context->initialLineState->AddChangeListener(&SubsEditBox::OnLineInitialTextChanged, this),
 	 });
 
-	if (use_stc && edit_ctrl_stc) {
-		edit_ctrl_stc->SetFocus();
-	} else if (edit_ctrl_tc) {
-		edit_ctrl_tc->SetFocus();
-	}
-
 	bool show_original = OPT_GET("Subtitle/Show Original")->GetBool();
 	if (show_original) {
 		split_box->SetValue(true);
@@ -410,9 +404,16 @@ void SubsEditBox::UpdateFields(int type, bool repopulate_lists) {
 
 	if (type & AssFile::COMMIT_DIAG_TEXT) {
 #ifdef WITH_WXSTC
-		if (use_stc && edit_ctrl_stc) {
-			edit_ctrl_stc->SetTextTo(line->Text);
-		} else
+	if (use_stc) {
+	    edit_ctrl_stc->SetTextTo(line->Text);
+	}
+	else {
+#endif
+	    // Use SetTextTo for native control as well so the
+	    // TextSelectionController stays in sync (handles UTF-8 mapping).
+	    edit_ctrl_tc->SetTextTo(line->Text);
+#ifdef WITH_WXSTC
+	}
 #endif
 		if (edit_ctrl_tc) {
 			edit_ctrl_tc->SetValue(to_wx(line->Text));
@@ -500,7 +501,45 @@ void SubsEditBox::UpdateFrameTiming(agi::vfr::Framerate const& fps) {
 }
 
 void SubsEditBox::OnKeyDown(wxKeyEvent &event) {
+	// Allow IME to handle events first (only for STC)
+#ifdef WITH_WXSTC
+	if (use_stc) {
+		if (!osx::ime::process_key_event(edit_ctrl_stc, event))
+			hotkey::check("Subtitle Edit Box", c, event);
+	}
+	else
+		hotkey::check("Subtitle Edit Box", c, event);
+#else
 	hotkey::check("Subtitle Edit Box", c, event);
+#endif
+
+	// Toggle text layout direction on Ctrl + Shift (matches original fork behavior
+	// of using Ctrl + Right Shift; here we accept either shift key). This switches
+	// between LeftToRight and RightToLeft for the edit control and secondary editor.
+	if (event.GetKeyCode() == WXK_SHIFT && event.ControlDown() && event.ShiftDown()) {
+		// Determine active edit control and flip its layout direction
+		wxWindow *active_ctrl = nullptr;
+#ifdef WITH_WXSTC
+		active_ctrl = use_stc ? static_cast<wxWindow*>(edit_ctrl_stc) : static_cast<wxWindow*>(edit_ctrl_tc);
+#else
+		active_ctrl = static_cast<wxWindow*>(edit_ctrl_tc);
+#endif
+
+		if (active_ctrl) {
+			wxLayoutDirection cur = active_ctrl->GetLayoutDirection();
+			wxLayoutDirection next = (cur == wxLayout_RightToLeft) ? wxLayout_LeftToRight : wxLayout_RightToLeft;
+			active_ctrl->SetLayoutDirection(next);
+			if (secondary_editor) secondary_editor->SetLayoutDirection(next);
+
+			if (auto stc = dynamic_cast<wxStyledTextCtrl*>(active_ctrl)) {
+				stc->SetViewEOL(false); // trigger minimal refresh
+			}
+
+			// consume the event
+			event.Skip(false);
+			return;
+		}
+	}
 }
 
 #ifdef WITH_WXSTC
@@ -515,8 +554,7 @@ void SubsEditBox::OnChangeStc(wxStyledTextEvent &event) {
 #endif
 
 void SubsEditBox::OnChangeTc(wxCommandEvent& event) {
-	if (line && from_wx(edit_ctrl_tc->GetValue()) != line->Text.get()) {
-		commit_id = -1;
+	if (line && std::string(edit_ctrl_tc->GetValue().utf8_str()) != line->Text.get()) {
 		CommitText(_("modify text"));
 		UpdateCharacterCount(line->Text);
 	}

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -73,6 +73,7 @@
 #include <wx/settings.h>
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
+#include <wx/wx.h>
 #ifdef WITH_WXSTC
 #include <wx/stc/stc.h>
 #endif

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -57,9 +57,6 @@
 #include "timeedit_ctrl.h"
 #include "tooltip_manager.h"
 #include "validators.h"
-#ifdef __WXOSX__
-#include "osx/scintilla_ime.h"
-#endif
 
 #include <libaegisub/character_count.h>
 #include <libaegisub/util.h>
@@ -78,6 +75,9 @@
 #include <wx/spinctrl.h>
 #ifdef WITH_WXSTC
 #include <wx/stc/stc.h>
+#endif
+#ifdef __WXOSX__
+#include "osx/scintilla_ime.h"
 #endif
 
 namespace {

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -57,6 +57,9 @@
 #include "timeedit_ctrl.h"
 #include "tooltip_manager.h"
 #include "validators.h"
+#ifdef __WXOSX__
+#include "osx/scintilla_ime.h"
+#endif
 
 #include <libaegisub/character_count.h>
 #include <libaegisub/util.h>

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -50,6 +50,9 @@
 #include "project.h"
 #include "selection_controller.h"
 #include "subs_edit_ctrl.h"
+#ifdef WITH_WXSTC
+#include "subs_edit_ctrl_stc.h"
+#endif
 #include "text_selection_controller.h"
 #include "timeedit_ctrl.h"
 #include "tooltip_manager.h"
@@ -111,10 +114,12 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 , c(context)
 , undo_timer(GetEventHandler())
 #ifdef WITH_WXSTC
-, use_stc(OPT_GET("Subtitle/Use STC")->GetBool())
 , edit_ctrl_stc(nullptr)
 #endif
 , edit_ctrl_tc(nullptr)
+#ifdef WITH_WXSTC
+, use_stc(OPT_GET("Subtitle/Use STC")->GetBool())
+#endif
 {
 	using std::bind;
 
@@ -561,7 +566,7 @@ void SubsEditBox::OnChangeStc(wxStyledTextEvent &event) {
 }
 #endif
 
-void SubsEditBox::OnChangeTc(wxCommandEvent& event) {
+void SubsEditBox::OnChangeTc([[maybe_unused]] wxCommandEvent& event) {
 	if (line && std::string(edit_ctrl_tc->GetValue().utf8_str()) != line->Text.get()) {
 		CommitText(_("modify text"));
 		UpdateCharacterCount(line->Text);

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -50,9 +50,6 @@
 #include "project.h"
 #include "selection_controller.h"
 #include "subs_edit_ctrl.h"
-#ifdef WITH_WXSTC
-#include "subs_edit_ctrl_stc.h"
-#endif
 #include "text_selection_controller.h"
 #include "timeedit_ctrl.h"
 #include "tooltip_manager.h"
@@ -73,6 +70,9 @@
 #include <wx/settings.h>
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
+#ifdef WITH_WXSTC
+#include <wx/stc/stc.h>
+#endif
 
 namespace {
 
@@ -110,10 +110,12 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 : wxPanel(parent, -1, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | (OPT_GET("App/Dark Mode")->GetBool() ? wxBORDER_STATIC : wxRAISED_BORDER), "SubsEditBox")
 , c(context)
 , undo_timer(GetEventHandler())
-{
 #ifdef WITH_WXSTC
-	use_stc = OPT_GET("Subtitle/Use STC")->GetBool();
+, use_stc(OPT_GET("Subtitle/Use STC")->GetBool())
+, edit_ctrl_stc(nullptr)
 #endif
+, edit_ctrl_tc(nullptr)
+{
 	using std::bind;
 
 	// Top controls
@@ -242,6 +244,8 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	main_sizer->Add(edit_ctrl_tc, wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, 3));
 	edit_ctrl_tc->Bind(wxEVT_TEXT, &SubsEditBox::OnChangeTc, this);
 	context->textSelectionController->SetControl(edit_ctrl_tc);
+	// Bind the native wxTextCtrl to the TextSelectionController so selection
+	// coordinates are kept in sync (convert between UTF-8 and codepoints).
 	edit_ctrl_tc->SetFocus();
 #endif
 
@@ -501,11 +505,15 @@ void SubsEditBox::UpdateFrameTiming(agi::vfr::Framerate const& fps) {
 }
 
 void SubsEditBox::OnKeyDown(wxKeyEvent &event) {
-	// Allow IME to handle events first (only for STC)
+	// Allow IME to handle events first (only for STC on macOS)
 #ifdef WITH_WXSTC
 	if (use_stc) {
+#ifdef __WXOSX__
 		if (!osx::ime::process_key_event(edit_ctrl_stc, event))
 			hotkey::check("Subtitle Edit Box", c, event);
+#else
+		hotkey::check("Subtitle Edit Box", c, event);
+#endif
 	}
 	else
 		hotkey::check("Subtitle Edit Box", c, event);

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -111,6 +111,9 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 , c(context)
 , undo_timer(GetEventHandler())
 {
+#ifdef WITH_WXSTC
+	use_stc = OPT_GET("Subtitle/Use STC")->GetBool();
+#endif
 	using std::bind;
 
 	// Top controls
@@ -252,7 +255,6 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 
 	main_sizer->Add(secondary_editor,1,wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,3);
 	main_sizer->Add(souceline_editor,1,wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,3);
-	main_sizer->Add(edit_ctrl,1,wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,3);
 	main_sizer->Hide(secondary_editor);
 	main_sizer->Hide(souceline_editor);
 
@@ -285,8 +287,11 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 		context->initialLineState->AddChangeListener(&SubsEditBox::OnLineInitialTextChanged, this),
 	 });
 
-	context->textSelectionController->SetControl(edit_ctrl);
-	edit_ctrl->SetFocus();
+	if (use_stc && edit_ctrl_stc) {
+		edit_ctrl_stc->SetFocus();
+	} else if (edit_ctrl_tc) {
+		edit_ctrl_tc->SetFocus();
+	}
 
 	bool show_original = OPT_GET("Subtitle/Show Original")->GetBool();
 	if (show_original) {

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -422,15 +422,12 @@ void SubsEditBox::UpdateFields(int type, bool repopulate_lists) {
 	}
 	else {
 #endif
-	    // Use SetTextTo for native control as well so the
-	    // TextSelectionController stays in sync (handles UTF-8 mapping).
+	    // Use SetTextTo for native control so the text selection state stays in sync.
+	    // Do not call SetValue() again here; it wipes the entire text field in native mode.
 	    edit_ctrl_tc->SetTextTo(line->Text);
 #ifdef WITH_WXSTC
 	}
 #endif
-		if (edit_ctrl_tc) {
-			edit_ctrl_tc->SetValue(to_wx(line->Text));
-		}
 		souceline_editor->SetValue(to_wx(line->SourceLineText));
 		UpdateCharacterCount(line->Text);
 	}

--- a/src/subs_edit_box.h
+++ b/src/subs_edit_box.h
@@ -210,7 +210,7 @@ class SubsEditBox final : public wxPanel {
 	void OnChangeTc(wxCommandEvent& event);
 
 #ifdef WITH_WXSTC
-	bool use_stc = OPT_GET("Subtitle/Use STC")->GetBool();
+	bool use_stc = false;
 #endif
 
 	wxTextCtrl *secondary_editor;

--- a/src/subs_edit_box.h
+++ b/src/subs_edit_box.h
@@ -45,6 +45,9 @@ class AssDialogue;
 class AssStyle;
 class SubsTextEditCtrl;
 class TimeEdit;
+#ifdef WITH_WXSTC
+class SubsStyledTextEditCtrl;
+#endif
 class wxButton;
 class wxCheckBox;
 class wxRadioButton;
@@ -199,7 +202,17 @@ class SubsEditBox final : public wxPanel {
 
 	void SetDurationField();
 
-	SubsTextEditCtrl *edit_ctrl;
+#ifdef WITH_WXSTC
+	SubsStyledTextEditCtrl *edit_ctrl_stc = nullptr;
+	void OnChangeStc(wxStyledTextEvent &event);
+#endif
+	SubsTextEditCtrl *edit_ctrl_tc = nullptr;
+	void OnChangeTc(wxCommandEvent& event);
+
+#ifdef WITH_WXSTC
+	bool use_stc = OPT_GET("Subtitle/Use STC")->GetBool();
+#endif
+
 	wxTextCtrl *secondary_editor;
 	wxTextCtrl *souceline_editor;
 

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -549,7 +549,7 @@ wxMenu *SubsTextEditCtrl::GetLanguagesMenu(int base_id, wxString const& curLang,
 	return languageMenu;
 }
 
-void SubsTextEditCtrl::OnToggleRTL(wxCommandEvent &event) {
+void SubsTextEditCtrl::OnToggleRTL([[maybe_unused]] wxCommandEvent &event) {
 	bool current_rtl = OPT_GET("Subtitle/Edit Box/RTL Mode")->GetBool();
 	bool new_rtl = !current_rtl;
 	OPT_SET("Subtitle/Edit Box/RTL Mode")->SetBool(new_rtl);

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -84,36 +84,26 @@ enum {
 };
 
 SubsTextEditCtrl::SubsTextEditCtrl(wxWindow* parent, wxSize wsize, long style, agi::Context *context)
-: wxStyledTextCtrl(parent, -1, wxDefaultPosition, wsize, style)
+: wxTextCtrl(parent, -1, "", wxDefaultPosition, wsize, wxTE_MULTILINE | wxTE_WORDWRAP | style)
 , spellchecker(SpellCheckerFactory::GetSpellChecker())
 , thesaurus(std::make_unique<Thesaurus>())
 , context(context)
 {
-	// Set properties
-	SetWrapMode(wxSTC_WRAP_WORD);
-	SetMarginWidth(1,0);
-	UsePopUp(wxSTC_POPUP_NEVER);
-	SetStyles();
+	// Set font
+	wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+	font.SetEncoding(wxFONTENCODING_DEFAULT);
+	wxString fontname = FontFace("Subtitle/Edit Box");
+	if (!fontname.empty()) font.SetFaceName(fontname);
+	font.SetPointSize(OPT_GET("Subtitle/Edit Box/Font Size")->GetInt());
+	SetFont(font);
 
-	// Set hotkeys
-	CmdKeyClear(wxSTC_KEY_RETURN,wxSTC_KEYMOD_CTRL);
-	CmdKeyClear(wxSTC_KEY_RETURN,wxSTC_KEYMOD_SHIFT);
-	CmdKeyClear(wxSTC_KEY_RETURN,wxSTC_KEYMOD_NORM);
-	CmdKeyClear(wxSTC_KEY_TAB,wxSTC_KEYMOD_NORM);
-	CmdKeyClear(wxSTC_KEY_TAB,wxSTC_KEYMOD_SHIFT);
-	CmdKeyClear('D',wxSTC_KEYMOD_CTRL);
-	CmdKeyClear('L',wxSTC_KEYMOD_CTRL);
-	CmdKeyClear('L',wxSTC_KEYMOD_CTRL | wxSTC_KEYMOD_SHIFT);
-	CmdKeyClear('T',wxSTC_KEYMOD_CTRL);
-	CmdKeyClear('T',wxSTC_KEYMOD_CTRL | wxSTC_KEYMOD_SHIFT);
-	CmdKeyClear('U',wxSTC_KEYMOD_CTRL);
+	// Apply RTL mode from config if enabled
+	if (OPT_GET("Subtitle/Edit Box/RTL Mode")->GetBool())
+		SetLayoutDirection(wxLayout_RightToLeft);
 
 	using std::bind;
 
 	Bind(wxEVT_CHAR_HOOK, &SubsTextEditCtrl::OnKeyDown, this);
-
-	Bind(wxEVT_MENU, bind(&cmd::call, "edit/comment", context), EDIT_MENU_COMMENT);
-
 	Bind(wxEVT_MENU, bind(&SubsTextEditCtrl::Cut, this), EDIT_MENU_CUT);
 	Bind(wxEVT_MENU, bind(&SubsTextEditCtrl::Copy, this), EDIT_MENU_COPY);
 	Bind(wxEVT_MENU, bind(&SubsTextEditCtrl::Paste, this), EDIT_MENU_PASTE);
@@ -127,42 +117,19 @@ SubsTextEditCtrl::SubsTextEditCtrl(wxWindow* parent, wxSize wsize, long style, a
 
 	Bind(wxEVT_MENU, &SubsTextEditCtrl::OnToggleRTL, this, EDIT_MENU_RTL);
 	Bind(wxEVT_CONTEXT_MENU, &SubsTextEditCtrl::OnContextMenu, this);
-	Bind(wxEVT_RIGHT_DOWN, &SubsTextEditCtrl::OnRightDown, this);
-	Bind(wxEVT_IDLE, std::bind(&SubsTextEditCtrl::UpdateCallTip, this));
-	Bind(wxEVT_STC_DOUBLECLICK, &SubsTextEditCtrl::OnDoubleClick, this);
-	Bind(wxEVT_STC_STYLENEEDED, [this](wxStyledTextEvent&) {
-		{
-			std::string text = GetTextRaw().data();
-			if (text == line_text) return;
-			line_text = std::move(text);
-		}
 
-		UpdateStyle();
+	// Subscribe to font and color changes
+	OPT_SUB("Subtitle/Edit Box/Font Face", [this](agi::OptionValue const&) {
+		wxFont font = GetFont();
+		font.SetFaceName(FontFace("Subtitle/Edit Box"));
+		SetFont(font);
+	});
+	OPT_SUB("Subtitle/Edit Box/Font Size", [this](agi::OptionValue const&) {
+		wxFont font = GetFont();
+		font.SetPointSize(OPT_GET("Subtitle/Edit Box/Font Size")->GetInt());
+		SetFont(font);
 	});
 
-	OPT_SUB("Subtitle/Edit Box/Font Face", &SubsTextEditCtrl::SetStyles, this);
-	OPT_SUB("Subtitle/Edit Box/Font Size", &SubsTextEditCtrl::SetStyles, this);
-	Subscribe("Normal");
-	Subscribe("Comment");
-	Subscribe("Drawing Command");
-	Subscribe("Drawing X");
-	Subscribe("Drawing Y");
-	OPT_SUB("Colour/Subtitle/Syntax/Underline/Drawing Endpoint", &SubsTextEditCtrl::SetStyles, this);
-	Subscribe("Brackets");
-	Subscribe("Slashes");
-	Subscribe("Tags");
-	Subscribe("Error");
-	Subscribe("Parameters");
-	Subscribe("Line Break");
-	Subscribe("Karaoke Template");
-	Subscribe("Karaoke Variable");
-
-	if (OPT_GET("Subtitle/Edit Box/RTL Mode")->GetBool())
-		SetLayoutDirection(wxLayout_RightToLeft);
-
-	OPT_SUB("Colour/Subtitle/Background", &SubsTextEditCtrl::SetStyles, this);
-	OPT_SUB("Subtitle/Highlight/Syntax", &SubsTextEditCtrl::UpdateStyle, this);
-	OPT_SUB("App/Call Tips", &SubsTextEditCtrl::UpdateCallTip, this);
 	OPT_SUB("Subtitle/Edit Box/RTL Mode", [this](agi::OptionValue const& opt) {
 		SetLayoutDirection(opt.GetBool() ? wxLayout_RightToLeft : wxLayout_LeftToRight);
 		Refresh();
@@ -170,13 +137,11 @@ SubsTextEditCtrl::SubsTextEditCtrl(wxWindow* parent, wxSize wsize, long style, a
 
 	Bind(wxEVT_MENU, [this](wxCommandEvent&) {
 		if (spellchecker) spellchecker->AddWord(currentWord);
-		UpdateStyle();
 		SetFocus();
 	}, EDIT_MENU_ADD_TO_DICT);
 
 	Bind(wxEVT_MENU, [this](wxCommandEvent&) {
 		if (spellchecker) spellchecker->RemoveWord(currentWord);
-		UpdateStyle();
 		SetFocus();
 	}, EDIT_MENU_REMOVE_FROM_DICT);
 }
@@ -184,159 +149,39 @@ SubsTextEditCtrl::SubsTextEditCtrl(wxWindow* parent, wxSize wsize, long style, a
 SubsTextEditCtrl::~SubsTextEditCtrl() {
 }
 
-void SubsTextEditCtrl::Subscribe(std::string const& name) {
-	OPT_SUB("Colour/Subtitle/Syntax/" + name, &SubsTextEditCtrl::SetStyles, this);
-	OPT_SUB("Colour/Subtitle/Syntax/Background/" + name, &SubsTextEditCtrl::SetStyles, this);
-	OPT_SUB("Colour/Subtitle/Syntax/Bold/" + name, &SubsTextEditCtrl::SetStyles, this);
-}
-
-BEGIN_EVENT_TABLE(SubsTextEditCtrl,wxStyledTextCtrl)
-	EVT_KILL_FOCUS(SubsTextEditCtrl::OnLoseFocus)
-
-	EVT_MENU_RANGE(EDIT_MENU_SUGGESTIONS,EDIT_MENU_THESAURUS-1,SubsTextEditCtrl::OnUseSuggestion)
-	EVT_MENU_RANGE(EDIT_MENU_THESAURUS_SUGS,EDIT_MENU_DIC_LANGUAGE-1,SubsTextEditCtrl::OnUseSuggestion)
-	EVT_MENU_RANGE(EDIT_MENU_DIC_LANGS,EDIT_MENU_THES_LANGUAGE-1,SubsTextEditCtrl::OnSetDicLanguage)
-	EVT_MENU_RANGE(EDIT_MENU_THES_LANGS,EDIT_MENU_THES_LANGS+LANGS_MAX,SubsTextEditCtrl::OnSetThesLanguage)
-END_EVENT_TABLE()
-
-void SubsTextEditCtrl::OnLoseFocus(wxFocusEvent &event) {
-	CallTipCancel();
-	event.Skip();
-}
-
 void SubsTextEditCtrl::OnKeyDown(wxKeyEvent &event) {
-	event.Skip();
+	// Handle Shift+Return for soft line breaks (ASS newline)
+	if (event.GetKeyCode() == WXK_RETURN && event.GetModifiers() == wxMOD_SHIFT) {
+		long sel_start = GetInsertionPoint();
+		long sel_end = sel_start;
+		GetSelection(&sel_start, &sel_end);
 
-	// Workaround for wxSTC eating tabs.
-	if (event.GetKeyCode() == WXK_TAB)
-		Navigate(event.ShiftDown() ? wxNavigationKeyEvent::IsBackward : wxNavigationKeyEvent::IsForward);
-	else if (event.GetKeyCode() == WXK_RETURN && event.GetModifiers() == wxMOD_SHIFT) {
-		auto sel_start = GetSelectionStart(), sel_end = GetSelectionEnd();
-		wxCharBuffer old = GetTextRaw();
-		std::string data(old.data(), sel_start);
-		data.append(OPT_GET("Subtitle/Edit Box/Soft Line Break")->GetBool() ? "\\n" : "\\N");
-		data.append(old.data() + sel_end, old.length() - sel_end);
-		SetTextRaw(data.c_str());
-
-		SetSelection(sel_start + 2, sel_start + 2);
+		wxString text = GetValue();
+		wxString new_text = text.substr(0, sel_start) + 
+		                    (OPT_GET("Subtitle/Edit Box/Soft Line Break")->GetBool() ? "\\n" : "\\N") +
+		                    text.substr(sel_end);
+		
+		SetValue(new_text);
+		SetInsertionPoint(sel_start + 2);
 		event.Skip(false);
-	}
-}
-
-void SubsTextEditCtrl::SetSyntaxStyle(int id, wxFont &font, std::string const& name, wxColor const& default_background) {
-	StyleSetFont(id, font);
-	StyleSetBold(id, OPT_GET("Colour/Subtitle/Syntax/Bold/" + name)->GetBool());
-	StyleSetForeground(id, to_wx(OPT_GET("Colour/Subtitle/Syntax/" + name)->GetColor()));
-	const agi::OptionValue *background = OPT_GET("Colour/Subtitle/Syntax/Background/" + name);
-	if (background->GetType() == agi::OptionType::Color)
-		StyleSetBackground(id, to_wx(background->GetColor()));
-	else
-		StyleSetBackground(id, default_background);
-}
-
-void SubsTextEditCtrl::SetStyles() {
-	wxFont font = *wxNORMAL_FONT;
-	font.SetEncoding(wxFONTENCODING_DEFAULT); // this solves problems with some fonts not working properly
-	wxString fontname = FontFace("Subtitle/Edit Box");
-	if (!fontname.empty()) font.SetFaceName(fontname);
-	font.SetPointSize(OPT_GET("Subtitle/Edit Box/Font Size")->GetInt());
-
-	auto default_background = to_wx(OPT_GET("Colour/Subtitle/Background")->GetColor());
-
-	namespace ss = agi::ass::SyntaxStyle;
-	SetSyntaxStyle(ss::NORMAL, font, "Normal", default_background);
-	SetSyntaxStyle(ss::COMMENT, font, "Comment", default_background);
-	SetSyntaxStyle(ss::DRAWING_CMD, font, "Drawing Command", default_background);
-	SetSyntaxStyle(ss::DRAWING_X, font, "Drawing X", default_background);
-	SetSyntaxStyle(ss::DRAWING_Y, font, "Drawing Y", default_background);
-	SetSyntaxStyle(ss::DRAWING_ENDPOINT_X, font, "Drawing X", default_background);
-	SetSyntaxStyle(ss::DRAWING_ENDPOINT_Y, font, "Drawing Y", default_background);
-	StyleSetUnderline(ss::DRAWING_ENDPOINT_X, OPT_GET("Colour/Subtitle/Syntax/Underline/Drawing Endpoint")->GetBool());
-	StyleSetUnderline(ss::DRAWING_ENDPOINT_Y, OPT_GET("Colour/Subtitle/Syntax/Underline/Drawing Endpoint")->GetBool());
-	SetSyntaxStyle(ss::OVERRIDE, font, "Brackets", default_background);
-	SetSyntaxStyle(ss::PUNCTUATION, font, "Slashes", default_background);
-	SetSyntaxStyle(ss::TAG, font, "Tags", default_background);
-	SetSyntaxStyle(ss::ERROR, font, "Error", default_background);
-	SetSyntaxStyle(ss::PARAMETER, font, "Parameters", default_background);
-	SetSyntaxStyle(ss::LINE_BREAK, font, "Line Break", default_background);
-	SetSyntaxStyle(ss::KARAOKE_TEMPLATE, font, "Karaoke Template", default_background);
-	SetSyntaxStyle(ss::KARAOKE_VARIABLE, font, "Karaoke Variable", default_background);
-
-	SetCaretForeground(StyleGetForeground(ss::NORMAL));
-	StyleSetBackground(wxSTC_STYLE_DEFAULT, default_background);
-
-	// Misspelling indicator
-	IndicatorSetStyle(0,wxSTC_INDIC_SQUIGGLE);
-	IndicatorSetForeground(0,wxColour(255,0,0));
-}
-
-void SubsTextEditCtrl::UpdateStyle() {
-	AssDialogue *diag = context ? context->selectionController->GetActiveLine() : nullptr;
-	bool template_line = diag && diag->Comment && (boost::istarts_with(diag->Effect.get(), "template") || boost::istarts_with(diag->Effect.get(), "mixin"));
-
-	tokenized_line = agi::ass::TokenizeDialogueBody(line_text, template_line);
-	agi::ass::SplitWords(line_text, tokenized_line);
-
-	cursor_pos = -1;
-	UpdateCallTip();
-
-	StartStyling(0);
-
-	if (!OPT_GET("Subtitle/Highlight/Syntax")->GetBool()) {
-		SetStyling(line_text.size(), 0);
 		return;
 	}
 
-	if (line_text.empty()) return;
-
-	SetIndicatorCurrent(0);
-	size_t pos = 0;
-	for (auto const& style_range : agi::ass::SyntaxHighlight(line_text, tokenized_line, spellchecker.get())) {
-		if (style_range.type == agi::ass::SyntaxStyle::SPELLING) {
-			SetStyling(style_range.length, agi::ass::SyntaxStyle::NORMAL);
-			IndicatorFillRange(pos, style_range.length);
-		}
-		else {
-			SetStyling(style_range.length, style_range.type);
-			IndicatorClearRange(pos, style_range.length);
-		}
-		pos += style_range.length;
-	}
+	// For all other keys, let the default handler process them
+	event.Skip();
 }
 
-void SubsTextEditCtrl::UpdateCallTip() {
-	if (!OPT_GET("App/Call Tips")->GetBool()) return;
 
-	int pos = GetCurrentPos();
-	if (pos == cursor_pos) return;
-	cursor_pos = pos;
-
-	agi::Calltip new_calltip = agi::GetCalltip(tokenized_line, line_text, pos);
-
-	if (!new_calltip.text) {
-		CallTipCancel();
-		return;
-	}
-
-	if (!CallTipActive() || calltip_position != new_calltip.tag_position || calltip_text != new_calltip.text)
-		CallTipShow(new_calltip.tag_position, wxString::FromUTF8Unchecked(new_calltip.text));
-
-	calltip_position = new_calltip.tag_position;
-	calltip_text = new_calltip.text;
-
-	CallTipSetHighlight(new_calltip.highlight_start, new_calltip.highlight_end);
-}
 
 void SubsTextEditCtrl::SetTextTo(std::string const& text) {
-	// Mirror STC behaviour: preserve insertion point, update selection controller
 	SetEvtHandlerEnabled(false);
 	Freeze();
 
 	long insertion_point = GetInsertionPoint();
 
-	// Get current value as std::string
-	wxCharBuffer curbuf = GetValue().utf8_str();
-	std::string cur = curbuf.data() ? std::string(curbuf.data(), curbuf.length()) : std::string();
+	// Get current value as UTF-8 for proper position tracking
+	wxString cur_wx = GetValue();
+	std::string cur(cur_wx.utf8_str());
 
 	// Compute old character index (clamped)
 	size_t clamp_pos = std::min<size_t>(cur.size(), static_cast<size_t>(std::max<long>(0, insertion_point)));
@@ -367,26 +212,15 @@ void SubsTextEditCtrl::Paste() {
 	boost::replace_all(data, "\n", "\\N");
 	boost::replace_all(data, "\r", "\\N");
 
-	wxCharBuffer old = GetTextRaw();
-	data.insert(0, old.data(), GetSelectionStart());
-	int sel_start = data.size();
-	data.append(old.data() + GetSelectionEnd());
+	wxString cur_text = GetValue();
+	long sel_start, sel_end;
+	GetSelection(&sel_start, &sel_end);
 
-	SetTextRaw(data.c_str());
+	wxString new_text = cur_text.substr(0, sel_start) + to_wx(data) + cur_text.substr(sel_end);
+	SetValue(new_text);
 
-	SetSelectionStart(sel_start);
-	SetSelectionEnd(sel_start);
-}
-
-void SubsTextEditCtrl::RestoreSelection(int anchor, int caret) {
-	// Not SetSelection: wxStyledTextCtrl implements it as SCI_SETSELECTIONSTART followed by
-	// SCI_SETSELECTIONEND, and Scintilla clamps both of those to anchor <= caret. A selection
-	// dragged right to left has the anchor at the higher position, so the first message
-	// collapsed the range onto the anchor and the second collapsed it onto the caret, which is
-	// why restoring only ever worked for selections made left to right. SCI_SETANCHOR and
-	// SCI_SETCURRENTPOS each move one end and leave the other alone, so the direction survives.
-	SetAnchor(anchor);
-	SetCurrentPos(caret);
+	long new_pos = sel_start + data.size();
+	SetInsertionPoint(new_pos);
 }
 
 void SubsTextEditCtrl::OnRightDown(wxMouseEvent &event) {
@@ -394,27 +228,26 @@ void SubsTextEditCtrl::OnRightDown(wxMouseEvent &event) {
 	right_click_anchor = GetAnchor();
 	right_click_caret = GetCurrentPos();
 	right_click_position = PositionFromPoint(event.GetPosition());
-	RestoreSelection(right_click_anchor, right_click_caret);
+	SetSelection(right_click_anchor, right_click_caret);
 	// Do not pass the click to Scintilla: its native handler can move the caret or
 	// discard the selection before WM_CONTEXTMENU opens our existing popup menu.
 }
 
 void SubsTextEditCtrl::OnContextMenu(wxContextMenuEvent &event) {
 	wxPoint pos = event.GetPosition();
-	int activePos;
-	if (right_click_pending) {
-		activePos = right_click_position;
-		RestoreSelection(right_click_anchor, right_click_caret);
-		right_click_pending = false;
+	long insertion_point;
+	
+	if (pos == wxDefaultPosition)
+		insertion_point = GetInsertionPoint();
+	else {
+		wxPoint screen_pos = ScreenToClient(pos);
+		insertion_point = XYToPosition(screen_pos.x, screen_pos.y);
+		if (insertion_point < 0) insertion_point = GetInsertionPoint();
 	}
-	else if (pos == wxDefaultPosition)
-		activePos = GetCurrentPos();
-	else
-		activePos = PositionFromPoint(ScreenToClient(pos));
-	if (activePos < 0) activePos = GetCurrentPos();
 
-	currentWordPos = GetBoundsOfWordAtPosition(activePos);
-	currentWord = line_text.substr(currentWordPos.first, currentWordPos.second);
+	currentWordPos = GetBoundsOfWordAtPosition(insertion_point);
+	wxString text = GetValue();
+	currentWord = std::string(text.substr(currentWordPos.first, currentWordPos.second).utf8_str());
 
 	wxMenu menu;
 
@@ -436,8 +269,8 @@ void SubsTextEditCtrl::OnContextMenu(wxContextMenuEvent &event) {
 	AddThesaurusEntries(menu);
 
 	// Standard actions
-	menu.Append(EDIT_MENU_CUT,_("Cu&t"))->Enable(GetSelectionStart()-GetSelectionEnd() != 0);
-	menu.Append(EDIT_MENU_COPY,_("&Copy"))->Enable(GetSelectionStart()-GetSelectionEnd() != 0);
+	menu.Append(EDIT_MENU_CUT,_("Cu&t"))->Enable(GetStringSelection().length() > 0);
+	menu.Append(EDIT_MENU_COPY,_("&Copy"))->Enable(GetStringSelection().length() > 0);
 	menu.Append(EDIT_MENU_PASTE,_("&Paste"))->Enable(CanPaste());
 	menu.AppendSeparator();
 	menu.Append(EDIT_MENU_SELECT_ALL,_("Select &All"));
@@ -456,19 +289,12 @@ void SubsTextEditCtrl::OnContextMenu(wxContextMenuEvent &event) {
 	PopupMenu(&menu);
 }
 
-void SubsTextEditCtrl::OnDoubleClick(wxStyledTextEvent &evt) {
-	int pos = evt.GetPosition();
-	if (pos == -1 && !tokenized_line.empty()) {
-		auto tok = tokenized_line.back();
-		SetSelection(line_text.size() - tok.length, line_text.size());
-	}
-	else {
-		auto bounds = GetBoundsOfWordAtPosition(evt.GetPosition());
-		if (bounds.second != 0)
-			SetSelection(bounds.first, bounds.first + bounds.second);
-		else
-			evt.Skip();
-	}
+void SubsTextEditCtrl::OnDoubleClick([[maybe_unused]] wxMouseEvent &evt) {
+	// Double-click word selection
+	long insertion = GetInsertionPoint();
+	auto bounds = GetBoundsOfWordAtPosition(insertion);
+	if (bounds.second != 0)
+		SetSelection(bounds.first, bounds.first + bounds.second);
 }
 
 void SubsTextEditCtrl::AddSpellCheckerEntries(wxMenu &menu) {
@@ -625,15 +451,18 @@ void SubsTextEditCtrl::OnSetThesLanguage(wxCommandEvent &event) {
 }
 
 std::pair<int, int> SubsTextEditCtrl::GetBoundsOfWordAtPosition(int pos) {
-	int len = 0;
-	for (auto const& tok : tokenized_line) {
-		if (len + (int)tok.length > pos) {
-			if (tok.type == agi::ass::DialogueTokenType::WORD)
-				return {len, tok.length};
-			return {0, 0};
-		}
-		len += tok.length;
-	}
+	wxString text = GetValue();
+	if (pos < 0 || pos > (int)text.length()) return {0, 0};
 
-	return {0, 0};
+	// Find the start of the word (scan backwards)
+	int start = pos;
+	while (start > 0 && wxIsalnum(text[start - 1]))
+		start--;
+
+	// Find the end of the word (scan forward)
+	int end = pos;
+	while (end < (int)text.length() && wxIsalnum(text[end]))
+		end++;
+
+	return {start, end - start};
 }

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -328,17 +328,16 @@ void SubsTextEditCtrl::UpdateCallTip() {
 }
 
 void SubsTextEditCtrl::SetTextTo(std::string const& text) {
+	// Preserve the cursor position without wiping the whole control when we update
+	// the dialog text from a tag/color operation.
 	SetEvtHandlerEnabled(false);
 	Freeze();
 
-	auto insertion_point = GetInsertionPoint();
-	if (static_cast<size_t>(insertion_point) > line_text.size())
-		line_text = GetTextRaw().data();
+	const long insertion_point = std::max<long>(0, GetInsertionPoint());
+	long new_insertion_point = std::min<long>(static_cast<long>(text.size()), insertion_point);
+
 	auto old_pos = agi::CharacterCount(std::string_view(line_text).substr(0, insertion_point), 0);
 	line_text.clear();
-
-	// Simply clamp insertion point to new text length
-	long new_insertion_point = std::min<long>(text.size(), insertion_point);
 
 	if (context) {
 		context->textSelectionController->SetSelection(0, 0);

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -328,9 +328,9 @@ void SubsTextEditCtrl::UpdateCallTip() {
 }
 
 void SubsTextEditCtrl::SetTextTo(std::string const& text) {
-	// Native wxTextCtrl positions are in wxString character units, not UTF-8 byte length.
-	// Using the UTF-8 byte count here causes out-of-range positions when a tag/color
-	// operation updates the text and selection afterwards.
+	// Native wxTextCtrl must be updated in one pass: set the text, then restore the
+	// insertion point. Resetting the selection/controller first clears the text and
+	// leaves the controller with invalid positions in non-STC mode.
 	SetEvtHandlerEnabled(false);
 	Freeze();
 
@@ -341,18 +341,13 @@ void SubsTextEditCtrl::SetTextTo(std::string const& text) {
 	auto old_pos = agi::CharacterCount(std::string_view(line_text).substr(0, insertion_point), 0);
 	line_text.clear();
 
-	if (context) {
-		context->textSelectionController->SetSelection(0, 0);
-		SetValue(new_text);
-		SetInsertionPoint(new_insertion_point);
-		context->textSelectionController->SetSelection(new_insertion_point, new_insertion_point);
-	}
-	else {
-		SetSelection(0, 0);
-		SetValue(new_text);
-		SetInsertionPoint(new_insertion_point);
+	SetValue(new_text);
+	SetInsertionPoint(new_insertion_point);
+
+	if (context)
+		context->textSelectionController->SetInsertionPoint(new_insertion_point);
+	else
 		SetSelection(new_insertion_point, new_insertion_point);
-	}
 
 	SetEvtHandlerEnabled(true);
 	Thaw();

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -338,12 +338,10 @@ void SubsTextEditCtrl::SetTextTo(std::string const& text) {
 	wxCharBuffer curbuf = GetValue().utf8_str();
 	std::string cur = curbuf.data() ? std::string(curbuf.data(), curbuf.length()) : std::string();
 
-	if (static_cast<size_t>(insertion_point) > cur.size())
-		; // nothing to do, cur is up-to-date
-
 	// Compute old character index (clamped)
 	size_t clamp_pos = std::min<size_t>(cur.size(), static_cast<size_t>(std::max<long>(0, insertion_point)));
-	size_t old_pos = agi::CharacterCount(cur.begin(), cur.begin() + clamp_pos, 0);
+	std::string_view cur_view(cur);
+	size_t old_pos = agi::CharacterCount(cur_view.substr(0, clamp_pos), 0);
 
 	if (context) {
 		context->textSelectionController->SetSelection(0, 0);

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -337,6 +337,9 @@ void SubsTextEditCtrl::SetTextTo(std::string const& text) {
 	auto old_pos = agi::CharacterCount(std::string_view(line_text).substr(0, insertion_point), 0);
 	line_text.clear();
 
+	// Simply clamp insertion point to new text length
+	long new_insertion_point = std::min<long>(text.size(), insertion_point);
+
 	if (context) {
 		context->textSelectionController->SetSelection(0, 0);
 		SetTextRaw(text.c_str());

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -328,28 +328,30 @@ void SubsTextEditCtrl::UpdateCallTip() {
 }
 
 void SubsTextEditCtrl::SetTextTo(std::string const& text) {
-	// Preserve the cursor position without wiping the whole control when we update
-	// the dialog text from a tag/color operation.
+	// Native wxTextCtrl positions are in wxString character units, not UTF-8 byte length.
+	// Using the UTF-8 byte count here causes out-of-range positions when a tag/color
+	// operation updates the text and selection afterwards.
 	SetEvtHandlerEnabled(false);
 	Freeze();
 
+	wxString new_text = to_wx(text);
 	const long insertion_point = std::max<long>(0, GetInsertionPoint());
-	long new_insertion_point = std::min<long>(static_cast<long>(text.size()), insertion_point);
+	const long new_insertion_point = std::min<long>(new_text.length(), insertion_point);
 
 	auto old_pos = agi::CharacterCount(std::string_view(line_text).substr(0, insertion_point), 0);
 	line_text.clear();
 
 	if (context) {
 		context->textSelectionController->SetSelection(0, 0);
-		SetTextRaw(text.c_str());
-		auto pos = agi::IndexOfCharacter(text, old_pos);
-		context->textSelectionController->SetSelection(pos, pos);
+		SetValue(new_text);
+		SetInsertionPoint(new_insertion_point);
+		context->textSelectionController->SetSelection(new_insertion_point, new_insertion_point);
 	}
 	else {
 		SetSelection(0, 0);
-		SetTextRaw(text.c_str());
-		auto pos = agi::IndexOfCharacter(text, old_pos);
-		SetSelection(pos, pos);
+		SetValue(new_text);
+		SetInsertionPoint(new_insertion_point);
+		SetSelection(new_insertion_point, new_insertion_point);
 	}
 
 	SetEvtHandlerEnabled(true);

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -223,16 +223,6 @@ void SubsTextEditCtrl::Paste() {
 	SetInsertionPoint(new_pos);
 }
 
-void SubsTextEditCtrl::OnRightDown(wxMouseEvent &event) {
-	right_click_pending = true;
-	right_click_anchor = GetAnchor();
-	right_click_caret = GetCurrentPos();
-	right_click_position = PositionFromPoint(event.GetPosition());
-	SetSelection(right_click_anchor, right_click_caret);
-	// Do not pass the click to Scintilla: its native handler can move the caret or
-	// discard the selection before WM_CONTEXTMENU opens our existing popup menu.
-}
-
 void SubsTextEditCtrl::OnContextMenu(wxContextMenuEvent &event) {
 	wxPoint pos = event.GetPosition();
 	long insertion_point;
@@ -287,14 +277,6 @@ void SubsTextEditCtrl::OnContextMenu(wxContextMenuEvent &event) {
 	}
 
 	PopupMenu(&menu);
-}
-
-void SubsTextEditCtrl::OnDoubleClick([[maybe_unused]] wxMouseEvent &evt) {
-	// Double-click word selection
-	long insertion = GetInsertionPoint();
-	auto bounds = GetBoundsOfWordAtPosition(insertion);
-	if (bounds.second != 0)
-		SetSelection(bounds.first, bounds.first + bounds.second);
 }
 
 void SubsTextEditCtrl::AddSpellCheckerEntries(wxMenu &menu) {
@@ -415,12 +397,14 @@ void SubsTextEditCtrl::OnUseSuggestion(wxCommandEvent &event) {
 		suggestion.resize(pos - 1);
 	}
 
-	// line_text needs to get cleared before SetTextRaw to ensure it gets reparsed
-	std::string new_text;
-	swap(line_text, new_text);
-	SetTextRaw(new_text.replace(currentWordPos.first, currentWordPos.second, suggestion).c_str());
-
-	SetSelection(currentWordPos.first, currentWordPos.first + suggestion.size());
+	// Replace the selected word using wxTextCtrl APIs.
+	// The old implementation used Scintilla's line_text/SetTextRaw state,
+	// which is not present after migrating SubsTextEditCtrl to wxTextCtrl.
+	wxString text = GetValue();
+	wxString suggestion_wx = to_wx(suggestion);
+	text.replace(currentWordPos.first, currentWordPos.second, suggestion_wx);
+	SetValue(text);
+	SetSelection(currentWordPos.first, currentWordPos.first + static_cast<int>(suggestion_wx.length()));
 	SetFocus();
 }
 
@@ -434,7 +418,7 @@ void SubsTextEditCtrl::OnSetDicLanguage(wxCommandEvent &event) {
 
 	OPT_SET("Tool/Spell Checker/Language")->SetString(lang);
 
-	UpdateStyle();
+	Refresh();
 }
 
 void SubsTextEditCtrl::OnSetThesLanguage(wxCommandEvent &event) {
@@ -447,7 +431,7 @@ void SubsTextEditCtrl::OnSetThesLanguage(wxCommandEvent &event) {
 	if (index >= 0) lang = langs[index];
 	OPT_SET("Tool/Thesaurus/Language")->SetString(lang);
 
-	UpdateStyle();
+	Refresh();
 }
 
 std::pair<int, int> SubsTextEditCtrl::GetBoundsOfWordAtPosition(int pos) {

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -328,26 +328,35 @@ void SubsTextEditCtrl::UpdateCallTip() {
 }
 
 void SubsTextEditCtrl::SetTextTo(std::string const& text) {
-	// Native wxTextCtrl must be updated in one pass: set the text, then restore the
-	// insertion point. Resetting the selection/controller first clears the text and
-	// leaves the controller with invalid positions in non-STC mode.
+	// Mirror STC behaviour: preserve insertion point, update selection controller
 	SetEvtHandlerEnabled(false);
 	Freeze();
 
-	wxString new_text = to_wx(text);
-	const long insertion_point = std::max<long>(0, GetInsertionPoint());
-	const long new_insertion_point = std::min<long>(new_text.length(), insertion_point);
+	long insertion_point = GetInsertionPoint();
 
-	auto old_pos = agi::CharacterCount(std::string_view(line_text).substr(0, insertion_point), 0);
-	line_text.clear();
+	// Get current value as std::string
+	wxCharBuffer curbuf = GetValue().utf8_str();
+	std::string cur = curbuf.data() ? std::string(curbuf.data(), curbuf.length()) : std::string();
 
-	SetValue(new_text);
-	SetInsertionPoint(new_insertion_point);
+	if (static_cast<size_t>(insertion_point) > cur.size())
+		; // nothing to do, cur is up-to-date
 
-	if (context)
-		context->textSelectionController->SetInsertionPoint(new_insertion_point);
-	else
-		SetSelection(new_insertion_point, new_insertion_point);
+	// Compute old character index (clamped)
+	size_t clamp_pos = std::min<size_t>(cur.size(), static_cast<size_t>(std::max<long>(0, insertion_point)));
+	size_t old_pos = agi::CharacterCount(cur.begin(), cur.begin() + clamp_pos, 0);
+
+	if (context) {
+		context->textSelectionController->SetSelection(0, 0);
+		SetValue(to_wx(text));
+		auto pos = agi::IndexOfCharacter(text, old_pos);
+		context->textSelectionController->SetSelection(pos, pos);
+	}
+	else {
+		SetSelection(0, 0);
+		SetValue(to_wx(text));
+		auto pos = agi::IndexOfCharacter(text, old_pos);
+		SetSelection(pos, pos);
+	}
 
 	SetEvtHandlerEnabled(true);
 	Thaw();

--- a/src/subs_edit_ctrl.h
+++ b/src/subs_edit_ctrl.h
@@ -29,8 +29,9 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
-#include <wx/stc/stc.h>
+#include <wx/textctrl.h>
 
 class Thesaurus;
 namespace agi {
@@ -40,8 +41,9 @@ namespace agi {
 }
 
 /// @class SubsTextEditCtrl
-/// @brief A Scintilla control with spell checking and syntax highlighting
-class SubsTextEditCtrl final : public wxStyledTextCtrl {
+/// @brief A native wxTextCtrl with spell checking and thesaurus support
+/// Provides basic text editing without syntax highlighting (for RTL and platform integration)
+class SubsTextEditCtrl final : public wxTextCtrl {
 	/// Backend spellchecker to use
 	std::unique_ptr<agi::SpellChecker> spellchecker;
 
@@ -63,52 +65,12 @@ class SubsTextEditCtrl final : public wxStyledTextCtrl {
 	/// Thesaurus suggestions for the last right-clicked word
 	std::vector<std::string> thesSugs;
 
-	/// Text of the currently shown calltip, to avoid flickering from
-	/// pointlessly reshowing the current tip
-	std::string calltip_text;
-
-	/// Position of the currently show calltip
-	size_t calltip_position = 0;
-
-	/// Cursor position which the current calltip is for
-	int cursor_pos;
-
-	/// The last seen line text, used to avoid reparsing the line for syntax
-	/// highlighting when possible
-	std::string line_text;
-
-	/// Tokenized version of line_text
-	std::vector<agi::ass::DialogueToken> tokenized_line;
-
-	/// Caret, anchor, and hit position captured before the native right-click handler can
-	/// move them. Opening the context menu must never alter the text selection.
-	bool right_click_pending = false;
-	int right_click_anchor = 0;
-	int right_click_caret = 0;
-	int right_click_position = -1;
-
-	/// Put the anchor and the caret back exactly where they were, including when the anchor
-	/// is the later of the two. wxStyledTextCtrl::SetSelection cannot express that.
-	void RestoreSelection(int anchor, int caret);
-
 	void OnContextMenu(wxContextMenuEvent &);
-	void OnRightDown(wxMouseEvent &);
-	void OnDoubleClick(wxStyledTextEvent&);
+	void OnKeyDown(wxKeyEvent &event);
+	void OnToggleRTL(wxCommandEvent &event);
 	void OnUseSuggestion(wxCommandEvent &event);
 	void OnSetDicLanguage(wxCommandEvent &event);
 	void OnSetThesLanguage(wxCommandEvent &event);
-	void OnLoseFocus(wxFocusEvent &event);
-	void OnKeyDown(wxKeyEvent &event);
-	void OnToggleRTL(wxCommandEvent &event);
-
-	void SetSyntaxStyle(int id, wxFont &font, std::string const& name, wxColor const& default_background);
-	void Subscribe(std::string const& name);
-
-	void StyleSpellCheck();
-	void UpdateCallTip();
-	void SetStyles();
-
-	void UpdateStyle();
 
 	/// Add the thesaurus suggestions to a menu
 	void AddThesaurusEntries(wxMenu &menu);
@@ -130,6 +92,4 @@ public:
 	void Paste() override;
 
 	std::pair<int, int> GetBoundsOfWordAtPosition(int pos);
-
-	DECLARE_EVENT_TABLE()
 };

--- a/src/subs_edit_ctrl_stc.cpp
+++ b/src/subs_edit_ctrl_stc.cpp
@@ -614,7 +614,7 @@ void SubsStyledTextEditCtrl::OnSetThesLanguage(wxCommandEvent &event) {
 	UpdateStyle();
 }
 
-void SubsStyledTextEditCtrl::OnToggleRTL(wxCommandEvent &event) {
+void SubsStyledTextEditCtrl::OnToggleRTL([[maybe_unused]] wxCommandEvent &event) {
 	// Get current RTL mode from config
 	bool current_rtl = OPT_GET("Subtitle/Edit Box/RTL Mode")->GetBool();
 	bool new_rtl = !current_rtl;

--- a/src/subs_edit_ctrl_stc.cpp
+++ b/src/subs_edit_ctrl_stc.cpp
@@ -44,7 +44,6 @@
 #include <libaegisub/ass/dialogue_parser.h>
 #include <libaegisub/calltip_provider.h>
 #include <libaegisub/character_count.h>
-#include <libaegisub/make_unique.h>
 #include <libaegisub/spellchecker.h>
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -97,7 +96,7 @@ enum {
 SubsStyledTextEditCtrl::SubsStyledTextEditCtrl(wxWindow* parent, wxSize wsize, long style, agi::Context *context)
 : wxStyledTextCtrl(parent, -1, wxDefaultPosition, wsize, style)
 , spellchecker(SpellCheckerFactory::GetSpellChecker())
-, thesaurus(agi::make_unique<Thesaurus>())
+, thesaurus(std::make_unique<Thesaurus>())
 , context(context)
 {
 	osx::ime::inject(this);

--- a/src/subs_edit_ctrl_stc.cpp
+++ b/src/subs_edit_ctrl_stc.cpp
@@ -99,7 +99,6 @@ SubsStyledTextEditCtrl::SubsStyledTextEditCtrl(wxWindow* parent, wxSize wsize, l
 , thesaurus(std::make_unique<Thesaurus>())
 , context(context)
 {
-	osx::ime::inject(this);
 
 	// Set properties
 	SetWrapMode(wxSTC_WRAP_WORD);
@@ -145,7 +144,7 @@ SubsStyledTextEditCtrl::SubsStyledTextEditCtrl(wxWindow* parent, wxSize wsize, l
 	Bind(wxEVT_MENU, &SubsStyledTextEditCtrl::OnToggleRTL, this, EDIT_MENU_RTL);
 	Bind(wxEVT_IDLE, std::bind(&SubsStyledTextEditCtrl::UpdateCallTip, this));
 	Bind(wxEVT_STC_DOUBLECLICK, &SubsStyledTextEditCtrl::OnDoubleClick, this);
-	Bind(wxEVT_STC_STYLENEEDED, [=](wxStyledTextEvent&) {
+	Bind(wxEVT_STC_STYLENEEDED, [this](wxStyledTextEvent&) {
 		{
 			std::string text = GetTextRaw().data();
 			if (text == line_text) return;
@@ -183,13 +182,13 @@ SubsStyledTextEditCtrl::SubsStyledTextEditCtrl(wxWindow* parent, wxSize wsize, l
 		Refresh();
 	});
 
-	Bind(wxEVT_MENU, [=](wxCommandEvent&) {
+	Bind(wxEVT_MENU, [this](wxCommandEvent&) {
 		if (spellchecker) spellchecker->AddWord(currentWord);
 		UpdateStyle();
 		SetFocus();
 	}, EDIT_MENU_ADD_TO_DICT);
 
-	Bind(wxEVT_MENU, [=](wxCommandEvent&) {
+	Bind(wxEVT_MENU, [this](wxCommandEvent&) {
 		if (spellchecker) spellchecker->RemoveWord(currentWord);
 		UpdateStyle();
 		SetFocus();
@@ -220,8 +219,6 @@ void SubsStyledTextEditCtrl::OnLoseFocus(wxFocusEvent &event) {
 }
 
 void SubsStyledTextEditCtrl::OnKeyDown(wxKeyEvent &event) {
-	if (osx::ime::process_key_event(this, event)) return;
-
 	// Handle Shift+Return for soft line breaks (ASS newline)
 	if (event.GetKeyCode() == WXK_RETURN && event.GetModifiers() == wxMOD_SHIFT) {
 		auto sel_start = GetSelectionStart(), sel_end = GetSelectionEnd();
@@ -365,14 +362,13 @@ void SubsStyledTextEditCtrl::UpdateCallTip() {
 }
 
 void SubsStyledTextEditCtrl::SetTextTo(std::string const& text) {
-	osx::ime::invalidate(this);
 	SetEvtHandlerEnabled(false);
 	Freeze();
 
 	auto insertion_point = GetInsertionPoint();
 	if (static_cast<size_t>(insertion_point) > line_text.size())
 		line_text = GetTextRaw().data();
-	auto old_pos = agi::CharacterCount(line_text.begin(), line_text.begin() + insertion_point, 0);
+	auto old_pos = agi::CharacterCount(std::string_view(line_text).substr(0, insertion_point), 0);
 	line_text.clear();
 
 	if (context) {

--- a/src/subs_edit_ctrl_stc.cpp
+++ b/src/subs_edit_ctrl_stc.cpp
@@ -150,7 +150,7 @@ SubsStyledTextEditCtrl::SubsStyledTextEditCtrl(wxWindow* parent, wxSize wsize, l
 		{
 			std::string text = GetTextRaw().data();
 			if (text == line_text) return;
-			line_text = move(text);
+			line_text = std::move(text);
 		}
 
 		UpdateStyle();

--- a/src/subs_edit_ctrl_stc.cpp
+++ b/src/subs_edit_ctrl_stc.cpp
@@ -18,7 +18,7 @@
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 // ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
 // LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
 // SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 // CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
@@ -27,7 +27,7 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
-#include "subs_edit_ctrl.h"
+#include "subs_edit_ctrl_stc.h"
 
 #include "ass_dialogue.h"
 #include "command/command.h"
@@ -44,6 +44,7 @@
 #include <libaegisub/ass/dialogue_parser.h>
 #include <libaegisub/calltip_provider.h>
 #include <libaegisub/character_count.h>
+#include <libaegisub/make_unique.h>
 #include <libaegisub/spellchecker.h>
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -55,6 +56,17 @@
 #include <wx/menu.h>
 #include <wx/settings.h>
 
+// Define macros for wxWidgets 3.1
+#ifndef wxSTC_KEYMOD_CTRL
+#define wxSTC_KEYMOD_CTRL wxSTC_SCMOD_CTRL
+#endif
+#ifndef wxSTC_KEYMOD_SHIFT
+#define wxSTC_KEYMOD_SHIFT wxSTC_SCMOD_SHIFT
+#endif
+#ifndef wxSTC_KEYMOD_NORM
+#define wxSTC_KEYMOD_NORM wxSTC_SCMOD_NORM
+#endif
+
 // Maximum number of languages (locales)
 // It should be above 100 (at least 242) and probably not more than 1000
 #define LANGS_MAX 1000
@@ -65,7 +77,6 @@ enum {
 	EDIT_MENU_SPLIT_PRESERVE = (wxID_HIGHEST + 1) + 4000,
 	EDIT_MENU_SPLIT_ESTIMATE,
 	EDIT_MENU_SPLIT_VIDEO,
-	EDIT_MENU_COMMENT,
 	EDIT_MENU_CUT,
 	EDIT_MENU_COPY,
 	EDIT_MENU_PASTE,
@@ -79,21 +90,28 @@ enum {
 	EDIT_MENU_DIC_LANGUAGE = (wxID_HIGHEST + 1) + 6000,
 	EDIT_MENU_DIC_LANGS,
 	EDIT_MENU_THES_LANGUAGE = EDIT_MENU_DIC_LANGUAGE + LANGS_MAX,
-	EDIT_MENU_THES_LANGS,
-	EDIT_MENU_RTL = (wxID_HIGHEST + 1) + 7000
+	EDIT_MENU_THES_LANGS
+    ,EDIT_MENU_RTL = (wxID_HIGHEST + 1) + 7000
 };
 
-SubsTextEditCtrl::SubsTextEditCtrl(wxWindow* parent, wxSize wsize, long style, agi::Context *context)
+SubsStyledTextEditCtrl::SubsStyledTextEditCtrl(wxWindow* parent, wxSize wsize, long style, agi::Context *context)
 : wxStyledTextCtrl(parent, -1, wxDefaultPosition, wsize, style)
 , spellchecker(SpellCheckerFactory::GetSpellChecker())
-, thesaurus(std::make_unique<Thesaurus>())
+, thesaurus(agi::make_unique<Thesaurus>())
 , context(context)
 {
+	osx::ime::inject(this);
+
 	// Set properties
 	SetWrapMode(wxSTC_WRAP_WORD);
 	SetMarginWidth(1,0);
-	UsePopUp(wxSTC_POPUP_NEVER);
+	UsePopUp(false);
 	SetStyles();
+	
+	// Apply RTL mode from config if enabled
+	if (OPT_GET("Subtitle/Edit Box/RTL Mode")->GetBool()) {
+		SetLayoutDirection(wxLayout_RightToLeft);
+	}
 
 	// Set hotkeys
 	CmdKeyClear(wxSTC_KEY_RETURN,wxSTC_KEYMOD_CTRL);
@@ -110,14 +128,12 @@ SubsTextEditCtrl::SubsTextEditCtrl(wxWindow* parent, wxSize wsize, long style, a
 
 	using std::bind;
 
-	Bind(wxEVT_CHAR_HOOK, &SubsTextEditCtrl::OnKeyDown, this);
+	Bind(wxEVT_CHAR_HOOK, &SubsStyledTextEditCtrl::OnKeyDown, this);
 
-	Bind(wxEVT_MENU, bind(&cmd::call, "edit/comment", context), EDIT_MENU_COMMENT);
-
-	Bind(wxEVT_MENU, bind(&SubsTextEditCtrl::Cut, this), EDIT_MENU_CUT);
-	Bind(wxEVT_MENU, bind(&SubsTextEditCtrl::Copy, this), EDIT_MENU_COPY);
-	Bind(wxEVT_MENU, bind(&SubsTextEditCtrl::Paste, this), EDIT_MENU_PASTE);
-	Bind(wxEVT_MENU, bind(&SubsTextEditCtrl::SelectAll, this), EDIT_MENU_SELECT_ALL);
+	Bind(wxEVT_MENU, bind(&SubsStyledTextEditCtrl::Cut, this), EDIT_MENU_CUT);
+	Bind(wxEVT_MENU, bind(&SubsStyledTextEditCtrl::Copy, this), EDIT_MENU_COPY);
+	Bind(wxEVT_MENU, bind(&SubsStyledTextEditCtrl::Paste, this), EDIT_MENU_PASTE);
+	Bind(wxEVT_MENU, bind(&SubsStyledTextEditCtrl::SelectAll, this), EDIT_MENU_SELECT_ALL);
 
 	if (context) {
 		Bind(wxEVT_MENU, bind(&cmd::call, "edit/line/split/preserve", context), EDIT_MENU_SPLIT_PRESERVE);
@@ -125,29 +141,29 @@ SubsTextEditCtrl::SubsTextEditCtrl(wxWindow* parent, wxSize wsize, long style, a
 		Bind(wxEVT_MENU, bind(&cmd::call, "edit/line/split/video", context), EDIT_MENU_SPLIT_VIDEO);
 	}
 
-	Bind(wxEVT_MENU, &SubsTextEditCtrl::OnToggleRTL, this, EDIT_MENU_RTL);
-	Bind(wxEVT_CONTEXT_MENU, &SubsTextEditCtrl::OnContextMenu, this);
-	Bind(wxEVT_RIGHT_DOWN, &SubsTextEditCtrl::OnRightDown, this);
-	Bind(wxEVT_IDLE, std::bind(&SubsTextEditCtrl::UpdateCallTip, this));
-	Bind(wxEVT_STC_DOUBLECLICK, &SubsTextEditCtrl::OnDoubleClick, this);
-	Bind(wxEVT_STC_STYLENEEDED, [this](wxStyledTextEvent&) {
+	Bind(wxEVT_CONTEXT_MENU, &SubsStyledTextEditCtrl::OnContextMenu, this);
+	// Bind RTL toggle so STC mode has an explicit toggle
+	Bind(wxEVT_MENU, &SubsStyledTextEditCtrl::OnToggleRTL, this, EDIT_MENU_RTL);
+	Bind(wxEVT_IDLE, std::bind(&SubsStyledTextEditCtrl::UpdateCallTip, this));
+	Bind(wxEVT_STC_DOUBLECLICK, &SubsStyledTextEditCtrl::OnDoubleClick, this);
+	Bind(wxEVT_STC_STYLENEEDED, [=](wxStyledTextEvent&) {
 		{
 			std::string text = GetTextRaw().data();
 			if (text == line_text) return;
-			line_text = std::move(text);
+			line_text = move(text);
 		}
 
 		UpdateStyle();
 	});
 
-	OPT_SUB("Subtitle/Edit Box/Font Face", &SubsTextEditCtrl::SetStyles, this);
-	OPT_SUB("Subtitle/Edit Box/Font Size", &SubsTextEditCtrl::SetStyles, this);
+	OPT_SUB("Subtitle/Edit Box/Font Face", &SubsStyledTextEditCtrl::SetStyles, this);
+	OPT_SUB("Subtitle/Edit Box/Font Size", &SubsStyledTextEditCtrl::SetStyles, this);
 	Subscribe("Normal");
 	Subscribe("Comment");
 	Subscribe("Drawing Command");
 	Subscribe("Drawing X");
 	Subscribe("Drawing Y");
-	OPT_SUB("Colour/Subtitle/Syntax/Underline/Drawing Endpoint", &SubsTextEditCtrl::SetStyles, this);
+	OPT_SUB("Colour/Subtitle/Syntax/Underline/Drawing Endpoint", &SubsStyledTextEditCtrl::SetStyles, this);
 	Subscribe("Brackets");
 	Subscribe("Slashes");
 	Subscribe("Tags");
@@ -157,60 +173,58 @@ SubsTextEditCtrl::SubsTextEditCtrl(wxWindow* parent, wxSize wsize, long style, a
 	Subscribe("Karaoke Template");
 	Subscribe("Karaoke Variable");
 
-	if (OPT_GET("Subtitle/Edit Box/RTL Mode")->GetBool())
-		SetLayoutDirection(wxLayout_RightToLeft);
-
-	OPT_SUB("Colour/Subtitle/Background", &SubsTextEditCtrl::SetStyles, this);
-	OPT_SUB("Subtitle/Highlight/Syntax", &SubsTextEditCtrl::UpdateStyle, this);
-	OPT_SUB("App/Call Tips", &SubsTextEditCtrl::UpdateCallTip, this);
+	OPT_SUB("Colour/Subtitle/Background", &SubsStyledTextEditCtrl::SetStyles, this);
+	OPT_SUB("Subtitle/Highlight/Syntax", &SubsStyledTextEditCtrl::UpdateStyle, this);
+	OPT_SUB("App/Call Tips", &SubsStyledTextEditCtrl::UpdateCallTip, this);
 	OPT_SUB("Subtitle/Edit Box/RTL Mode", [this](agi::OptionValue const& opt) {
-		SetLayoutDirection(opt.GetBool() ? wxLayout_RightToLeft : wxLayout_LeftToRight);
+		if (opt.GetBool())
+			SetLayoutDirection(wxLayout_RightToLeft);
+		else
+			SetLayoutDirection(wxLayout_LeftToRight);
 		Refresh();
 	});
 
-	Bind(wxEVT_MENU, [this](wxCommandEvent&) {
+	Bind(wxEVT_MENU, [=](wxCommandEvent&) {
 		if (spellchecker) spellchecker->AddWord(currentWord);
 		UpdateStyle();
 		SetFocus();
 	}, EDIT_MENU_ADD_TO_DICT);
 
-	Bind(wxEVT_MENU, [this](wxCommandEvent&) {
+	Bind(wxEVT_MENU, [=](wxCommandEvent&) {
 		if (spellchecker) spellchecker->RemoveWord(currentWord);
 		UpdateStyle();
 		SetFocus();
 	}, EDIT_MENU_REMOVE_FROM_DICT);
 }
 
-SubsTextEditCtrl::~SubsTextEditCtrl() {
+SubsStyledTextEditCtrl::~SubsStyledTextEditCtrl() {
 }
 
-void SubsTextEditCtrl::Subscribe(std::string const& name) {
-	OPT_SUB("Colour/Subtitle/Syntax/" + name, &SubsTextEditCtrl::SetStyles, this);
-	OPT_SUB("Colour/Subtitle/Syntax/Background/" + name, &SubsTextEditCtrl::SetStyles, this);
-	OPT_SUB("Colour/Subtitle/Syntax/Bold/" + name, &SubsTextEditCtrl::SetStyles, this);
+void SubsStyledTextEditCtrl::Subscribe(std::string const& name) {
+	OPT_SUB("Colour/Subtitle/Syntax/" + name, &SubsStyledTextEditCtrl::SetStyles, this);
+	OPT_SUB("Colour/Subtitle/Syntax/Background/" + name, &SubsStyledTextEditCtrl::SetStyles, this);
+	OPT_SUB("Colour/Subtitle/Syntax/Bold/" + name, &SubsStyledTextEditCtrl::SetStyles, this);
 }
 
-BEGIN_EVENT_TABLE(SubsTextEditCtrl,wxStyledTextCtrl)
-	EVT_KILL_FOCUS(SubsTextEditCtrl::OnLoseFocus)
+BEGIN_EVENT_TABLE(SubsStyledTextEditCtrl,wxStyledTextCtrl)
+	EVT_KILL_FOCUS(SubsStyledTextEditCtrl::OnLoseFocus)
 
-	EVT_MENU_RANGE(EDIT_MENU_SUGGESTIONS,EDIT_MENU_THESAURUS-1,SubsTextEditCtrl::OnUseSuggestion)
-	EVT_MENU_RANGE(EDIT_MENU_THESAURUS_SUGS,EDIT_MENU_DIC_LANGUAGE-1,SubsTextEditCtrl::OnUseSuggestion)
-	EVT_MENU_RANGE(EDIT_MENU_DIC_LANGS,EDIT_MENU_THES_LANGUAGE-1,SubsTextEditCtrl::OnSetDicLanguage)
-	EVT_MENU_RANGE(EDIT_MENU_THES_LANGS,EDIT_MENU_THES_LANGS+LANGS_MAX,SubsTextEditCtrl::OnSetThesLanguage)
+	EVT_MENU_RANGE(EDIT_MENU_SUGGESTIONS,EDIT_MENU_THESAURUS-1,SubsStyledTextEditCtrl::OnUseSuggestion)
+	EVT_MENU_RANGE(EDIT_MENU_THESAURUS_SUGS,EDIT_MENU_DIC_LANGUAGE-1,SubsStyledTextEditCtrl::OnUseSuggestion)
+	EVT_MENU_RANGE(EDIT_MENU_DIC_LANGS,EDIT_MENU_THES_LANGUAGE-1,SubsStyledTextEditCtrl::OnSetDicLanguage)
+	EVT_MENU_RANGE(EDIT_MENU_THES_LANGS,EDIT_MENU_THES_LANGS+LANGS_MAX,SubsStyledTextEditCtrl::OnSetThesLanguage)
 END_EVENT_TABLE()
 
-void SubsTextEditCtrl::OnLoseFocus(wxFocusEvent &event) {
+void SubsStyledTextEditCtrl::OnLoseFocus(wxFocusEvent &event) {
 	CallTipCancel();
 	event.Skip();
 }
 
-void SubsTextEditCtrl::OnKeyDown(wxKeyEvent &event) {
-	event.Skip();
+void SubsStyledTextEditCtrl::OnKeyDown(wxKeyEvent &event) {
+	if (osx::ime::process_key_event(this, event)) return;
 
-	// Workaround for wxSTC eating tabs.
-	if (event.GetKeyCode() == WXK_TAB)
-		Navigate(event.ShiftDown() ? wxNavigationKeyEvent::IsBackward : wxNavigationKeyEvent::IsForward);
-	else if (event.GetKeyCode() == WXK_RETURN && event.GetModifiers() == wxMOD_SHIFT) {
+	// Handle Shift+Return for soft line breaks (ASS newline)
+	if (event.GetKeyCode() == WXK_RETURN && event.GetModifiers() == wxMOD_SHIFT) {
 		auto sel_start = GetSelectionStart(), sel_end = GetSelectionEnd();
 		wxCharBuffer old = GetTextRaw();
 		std::string data(old.data(), sel_start);
@@ -219,11 +233,21 @@ void SubsTextEditCtrl::OnKeyDown(wxKeyEvent &event) {
 		SetTextRaw(data.c_str());
 
 		SetSelection(sel_start + 2, sel_start + 2);
-		event.Skip(false);
+		return;  // We handled it, don't skip
 	}
+
+	// For TAB, use the default navigation mechanism
+	if (event.GetKeyCode() == WXK_TAB) {
+		Navigate(event.ShiftDown() ? wxNavigationKeyEvent::IsBackward : wxNavigationKeyEvent::IsForward);
+		return;  // We handled it
+	}
+
+	// For all other keys (including Ctrl+Shift combos for RTL toggling on Windows),
+	// let the OS/IME and parent hotkey handler process them
+	event.Skip();
 }
 
-void SubsTextEditCtrl::SetSyntaxStyle(int id, wxFont &font, std::string const& name, wxColor const& default_background) {
+void SubsStyledTextEditCtrl::SetSyntaxStyle(int id, wxFont &font, std::string const& name, wxColor const& default_background) {
 	StyleSetFont(id, font);
 	StyleSetBold(id, OPT_GET("Colour/Subtitle/Syntax/Bold/" + name)->GetBool());
 	StyleSetForeground(id, to_wx(OPT_GET("Colour/Subtitle/Syntax/" + name)->GetColor()));
@@ -234,14 +258,20 @@ void SubsTextEditCtrl::SetSyntaxStyle(int id, wxFont &font, std::string const& n
 		StyleSetBackground(id, default_background);
 }
 
-void SubsTextEditCtrl::SetStyles() {
-	wxFont font = *wxNORMAL_FONT;
+void SubsStyledTextEditCtrl::SetStyles() {
+	wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
 	font.SetEncoding(wxFONTENCODING_DEFAULT); // this solves problems with some fonts not working properly
 	wxString fontname = FontFace("Subtitle/Edit Box");
 	if (!fontname.empty()) font.SetFaceName(fontname);
 	font.SetPointSize(OPT_GET("Subtitle/Edit Box/Font Size")->GetInt());
 
-	auto default_background = to_wx(OPT_GET("Colour/Subtitle/Background")->GetColor());
+	// In dark mode, use dark background; otherwise use configured color
+	wxColour default_background;
+	if (OPT_GET("App/Dark Mode")->GetBool()) {
+		default_background = wxColour(30, 30, 30);  // Dark gray
+	} else {
+		default_background = to_wx(OPT_GET("Colour/Subtitle/Background")->GetColor());
+	}
 
 	namespace ss = agi::ass::SyntaxStyle;
 	SetSyntaxStyle(ss::NORMAL, font, "Normal", default_background);
@@ -268,9 +298,13 @@ void SubsTextEditCtrl::SetStyles() {
 	// Misspelling indicator
 	IndicatorSetStyle(0,wxSTC_INDIC_SQUIGGLE);
 	IndicatorSetForeground(0,wxColour(255,0,0));
+
+	// IME pending text indicator
+	IndicatorSetStyle(1, wxSTC_INDIC_PLAIN);
+	IndicatorSetUnder(1, true);
 }
 
-void SubsTextEditCtrl::UpdateStyle() {
+void SubsStyledTextEditCtrl::UpdateStyle() {
 	AssDialogue *diag = context ? context->selectionController->GetActiveLine() : nullptr;
 	bool template_line = diag && diag->Comment && (boost::istarts_with(diag->Effect.get(), "template") || boost::istarts_with(diag->Effect.get(), "mixin"));
 
@@ -280,7 +314,11 @@ void SubsTextEditCtrl::UpdateStyle() {
 	cursor_pos = -1;
 	UpdateCallTip();
 
+#if wxVERSION_NUMBER >= 3100
 	StartStyling(0);
+#else
+	StartStyling(0, 255);
+#endif
 
 	if (!OPT_GET("Subtitle/Highlight/Syntax")->GetBool()) {
 		SetStyling(line_text.size(), 0);
@@ -304,7 +342,7 @@ void SubsTextEditCtrl::UpdateStyle() {
 	}
 }
 
-void SubsTextEditCtrl::UpdateCallTip() {
+void SubsStyledTextEditCtrl::UpdateCallTip() {
 	if (!OPT_GET("App/Call Tips")->GetBool()) return;
 
 	int pos = GetCurrentPos();
@@ -327,14 +365,15 @@ void SubsTextEditCtrl::UpdateCallTip() {
 	CallTipSetHighlight(new_calltip.highlight_start, new_calltip.highlight_end);
 }
 
-void SubsTextEditCtrl::SetTextTo(std::string const& text) {
+void SubsStyledTextEditCtrl::SetTextTo(std::string const& text) {
+	osx::ime::invalidate(this);
 	SetEvtHandlerEnabled(false);
 	Freeze();
 
 	auto insertion_point = GetInsertionPoint();
 	if (static_cast<size_t>(insertion_point) > line_text.size())
 		line_text = GetTextRaw().data();
-	auto old_pos = agi::CharacterCount(std::string_view(line_text).substr(0, insertion_point), 0);
+	auto old_pos = agi::CharacterCount(line_text.begin(), line_text.begin() + insertion_point, 0);
 	line_text.clear();
 
 	if (context) {
@@ -354,7 +393,7 @@ void SubsTextEditCtrl::SetTextTo(std::string const& text) {
 	Thaw();
 }
 
-void SubsTextEditCtrl::Paste() {
+void SubsStyledTextEditCtrl::Paste() {
 	std::string data = GetClipboard();
 
 	boost::replace_all(data, "\r\n", "\\N");
@@ -372,50 +411,18 @@ void SubsTextEditCtrl::Paste() {
 	SetSelectionEnd(sel_start);
 }
 
-void SubsTextEditCtrl::RestoreSelection(int anchor, int caret) {
-	// Not SetSelection: wxStyledTextCtrl implements it as SCI_SETSELECTIONSTART followed by
-	// SCI_SETSELECTIONEND, and Scintilla clamps both of those to anchor <= caret. A selection
-	// dragged right to left has the anchor at the higher position, so the first message
-	// collapsed the range onto the anchor and the second collapsed it onto the caret, which is
-	// why restoring only ever worked for selections made left to right. SCI_SETANCHOR and
-	// SCI_SETCURRENTPOS each move one end and leave the other alone, so the direction survives.
-	SetAnchor(anchor);
-	SetCurrentPos(caret);
-}
-
-void SubsTextEditCtrl::OnRightDown(wxMouseEvent &event) {
-	right_click_pending = true;
-	right_click_anchor = GetAnchor();
-	right_click_caret = GetCurrentPos();
-	right_click_position = PositionFromPoint(event.GetPosition());
-	RestoreSelection(right_click_anchor, right_click_caret);
-	// Do not pass the click to Scintilla: its native handler can move the caret or
-	// discard the selection before WM_CONTEXTMENU opens our existing popup menu.
-}
-
-void SubsTextEditCtrl::OnContextMenu(wxContextMenuEvent &event) {
+void SubsStyledTextEditCtrl::OnContextMenu(wxContextMenuEvent &event) {
 	wxPoint pos = event.GetPosition();
 	int activePos;
-	if (right_click_pending) {
-		activePos = right_click_position;
-		RestoreSelection(right_click_anchor, right_click_caret);
-		right_click_pending = false;
-	}
-	else if (pos == wxDefaultPosition)
+	if (pos == wxDefaultPosition)
 		activePos = GetCurrentPos();
 	else
 		activePos = PositionFromPoint(ScreenToClient(pos));
-	if (activePos < 0) activePos = GetCurrentPos();
 
 	currentWordPos = GetBoundsOfWordAtPosition(activePos);
 	currentWord = line_text.substr(currentWordPos.first, currentWordPos.second);
 
 	wxMenu menu;
-
-	cmd::Command *comment = cmd::get("edit/comment");
-	menu.Append(EDIT_MENU_COMMENT, comment->StrMenu(context));
-	menu.AppendSeparator();
-
 	if (spellchecker) {
 		AddSpellCheckerEntries(menu);
 
@@ -435,8 +442,6 @@ void SubsTextEditCtrl::OnContextMenu(wxContextMenuEvent &event) {
 	menu.Append(EDIT_MENU_PASTE,_("&Paste"))->Enable(CanPaste());
 	menu.AppendSeparator();
 	menu.Append(EDIT_MENU_SELECT_ALL,_("Select &All"));
-	menu.AppendSeparator();
-	menu.Append(EDIT_MENU_RTL, _("Right to left Reading order"));
 
 	// Split
 	if (context) {
@@ -447,10 +452,14 @@ void SubsTextEditCtrl::OnContextMenu(wxContextMenuEvent &event) {
 		menu.Append(EDIT_MENU_SPLIT_VIDEO, split_video->StrMenu(context))->Enable(split_video->Validate(context));
 	}
 
+	// Add explicit RTL toggle so STC mode always has the option
+	menu.AppendSeparator();
+	menu.Append(EDIT_MENU_RTL, _("Right to left Reading order"));
+
 	PopupMenu(&menu);
 }
 
-void SubsTextEditCtrl::OnDoubleClick(wxStyledTextEvent &evt) {
+void SubsStyledTextEditCtrl::OnDoubleClick(wxStyledTextEvent &evt) {
 	int pos = evt.GetPosition();
 	if (pos == -1 && !tokenized_line.empty()) {
 		auto tok = tokenized_line.back();
@@ -465,7 +474,7 @@ void SubsTextEditCtrl::OnDoubleClick(wxStyledTextEvent &evt) {
 	}
 }
 
-void SubsTextEditCtrl::AddSpellCheckerEntries(wxMenu &menu) {
+void SubsStyledTextEditCtrl::AddSpellCheckerEntries(wxMenu &menu) {
 	if (currentWord.empty()) return;
 
 	if (spellchecker->CanRemoveWord(currentWord))
@@ -495,7 +504,7 @@ void SubsTextEditCtrl::AddSpellCheckerEntries(wxMenu &menu) {
 	}
 }
 
-void SubsTextEditCtrl::AddThesaurusEntries(wxMenu &menu) {
+void SubsStyledTextEditCtrl::AddThesaurusEntries(wxMenu &menu) {
 	if (currentWord.empty()) return;
 
 	auto results = thesaurus->Lookup(currentWord);
@@ -539,7 +548,7 @@ void SubsTextEditCtrl::AddThesaurusEntries(wxMenu &menu) {
 	menu.AppendSeparator();
 }
 
-wxMenu *SubsTextEditCtrl::GetLanguagesMenu(int base_id, wxString const& curLang, wxArrayString const& langs) {
+wxMenu *SubsStyledTextEditCtrl::GetLanguagesMenu(int base_id, wxString const& curLang, wxArrayString const& langs) {
 	auto languageMenu = new wxMenu;
 	languageMenu->AppendRadioItem(base_id, _("Disable"))->Check(curLang.empty());
 
@@ -549,21 +558,13 @@ wxMenu *SubsTextEditCtrl::GetLanguagesMenu(int base_id, wxString const& curLang,
 	return languageMenu;
 }
 
-void SubsTextEditCtrl::OnToggleRTL(wxCommandEvent &event) {
-	bool current_rtl = OPT_GET("Subtitle/Edit Box/RTL Mode")->GetBool();
-	bool new_rtl = !current_rtl;
-	OPT_SET("Subtitle/Edit Box/RTL Mode")->SetBool(new_rtl);
-	SetLayoutDirection(new_rtl ? wxLayout_RightToLeft : wxLayout_LeftToRight);
-	Refresh();
-}
-
-void SubsTextEditCtrl::OnUseSuggestion(wxCommandEvent &event) {
+void SubsStyledTextEditCtrl::OnUseSuggestion(wxCommandEvent &event) {
 	std::string suggestion;
 	int sugIdx = event.GetId() - EDIT_MENU_THESAURUS_SUGS;
 	if (sugIdx >= 0)
 		suggestion = thesSugs[sugIdx];
 	else
-		suggestion = sugs[event.GetId() - EDIT_MENU_SUGGESTIONS];
+		suggestion = sugs[event.GetId() - EDIT_MENU_SUGGESTION];
 
 	size_t pos;
 	while ((pos = suggestion.rfind('(')) != std::string::npos) {
@@ -592,7 +593,7 @@ void SubsTextEditCtrl::OnUseSuggestion(wxCommandEvent &event) {
 	SetFocus();
 }
 
-void SubsTextEditCtrl::OnSetDicLanguage(wxCommandEvent &event) {
+void SubsStyledTextEditCtrl::OnSetDicLanguage(wxCommandEvent &event) {
 	std::vector<std::string> langs = spellchecker->GetLanguageList();
 
 	int index = event.GetId() - EDIT_MENU_DIC_LANGS - 1;
@@ -605,7 +606,7 @@ void SubsTextEditCtrl::OnSetDicLanguage(wxCommandEvent &event) {
 	UpdateStyle();
 }
 
-void SubsTextEditCtrl::OnSetThesLanguage(wxCommandEvent &event) {
+void SubsStyledTextEditCtrl::OnSetThesLanguage(wxCommandEvent &event) {
 	if (!thesaurus) return;
 
 	std::vector<std::string> langs = thesaurus->GetLanguageList();
@@ -618,7 +619,24 @@ void SubsTextEditCtrl::OnSetThesLanguage(wxCommandEvent &event) {
 	UpdateStyle();
 }
 
-std::pair<int, int> SubsTextEditCtrl::GetBoundsOfWordAtPosition(int pos) {
+void SubsStyledTextEditCtrl::OnToggleRTL(wxCommandEvent &event) {
+	// Get current RTL mode from config
+	bool current_rtl = OPT_GET("Subtitle/Edit Box/RTL Mode")->GetBool();
+	bool new_rtl = !current_rtl;
+	
+	// Update the config option
+	OPT_SET("Subtitle/Edit Box/RTL Mode")->SetBool(new_rtl);
+	
+	// Apply layout direction to the control
+	if (new_rtl)
+		SetLayoutDirection(wxLayout_RightToLeft);
+	else
+		SetLayoutDirection(wxLayout_LeftToRight);
+		
+	Refresh();
+}
+
+std::pair<int, int> SubsStyledTextEditCtrl::GetBoundsOfWordAtPosition(int pos) {
 	int len = 0;
 	for (auto const& tok : tokenized_line) {
 		if (len + (int)tok.length > pos) {

--- a/src/subs_edit_ctrl_stc.h
+++ b/src/subs_edit_ctrl_stc.h
@@ -18,7 +18,7 @@
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 // ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
 // LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
 // SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 // CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
@@ -39,9 +39,9 @@ namespace agi {
 	namespace ass { struct DialogueToken; }
 }
 
-/// @class SubsTextEditCtrl
+/// @class SubsStyledTextEditCtrl
 /// @brief A Scintilla control with spell checking and syntax highlighting
-class SubsTextEditCtrl final : public wxStyledTextCtrl {
+class SubsStyledTextEditCtrl final : public wxStyledTextCtrl {
 	/// Backend spellchecker to use
 	std::unique_ptr<agi::SpellChecker> spellchecker;
 
@@ -80,26 +80,14 @@ class SubsTextEditCtrl final : public wxStyledTextCtrl {
 	/// Tokenized version of line_text
 	std::vector<agi::ass::DialogueToken> tokenized_line;
 
-	/// Caret, anchor, and hit position captured before the native right-click handler can
-	/// move them. Opening the context menu must never alter the text selection.
-	bool right_click_pending = false;
-	int right_click_anchor = 0;
-	int right_click_caret = 0;
-	int right_click_position = -1;
-
-	/// Put the anchor and the caret back exactly where they were, including when the anchor
-	/// is the later of the two. wxStyledTextCtrl::SetSelection cannot express that.
-	void RestoreSelection(int anchor, int caret);
-
 	void OnContextMenu(wxContextMenuEvent &);
-	void OnRightDown(wxMouseEvent &);
 	void OnDoubleClick(wxStyledTextEvent&);
 	void OnUseSuggestion(wxCommandEvent &event);
 	void OnSetDicLanguage(wxCommandEvent &event);
 	void OnSetThesLanguage(wxCommandEvent &event);
+	void OnToggleRTL(wxCommandEvent &event);
 	void OnLoseFocus(wxFocusEvent &event);
 	void OnKeyDown(wxKeyEvent &event);
-	void OnToggleRTL(wxCommandEvent &event);
 
 	void SetSyntaxStyle(int id, wxFont &font, std::string const& name, wxColor const& default_background);
 	void Subscribe(std::string const& name);
@@ -119,12 +107,12 @@ class SubsTextEditCtrl final : public wxStyledTextCtrl {
 	/// Generate a languages submenu from a list of locales and a current language
 	/// @param base_id ID to use for the first menu item
 	/// @param curLang Currently selected language
-	/// @param langs Full list of languages
+	/// @param lang Full list of languages
 	wxMenu *GetLanguagesMenu(int base_id, wxString const& curLang, wxArrayString const& langs);
 
 public:
-	SubsTextEditCtrl(wxWindow* parent, wxSize size, long style, agi::Context *context);
-	~SubsTextEditCtrl();
+	SubsStyledTextEditCtrl(wxWindow* parent, wxSize size, long style, agi::Context *context);
+	~SubsStyledTextEditCtrl();
 
 	void SetTextTo(std::string const& text);
 	void Paste() override;

--- a/src/text_selection_controller.cpp
+++ b/src/text_selection_controller.cpp
@@ -29,77 +29,124 @@ void TextSelectionController::SetControl(wxStyledTextCtrl* ctrl) {
 
 void TextSelectionController::SetControl(wxTextCtrl* ctrl) {
 	ctrl_te = ctrl;
+	ctrl_stc = nullptr;
+	if (ctrl) {
+		ctrl->Bind(wxEVT_KEY_UP, &TextSelectionController::UpdateUI, this);
+		ctrl->Bind(wxEVT_LEFT_UP, &TextSelectionController::UpdateUI, this);
+	}
+#ifdef WITH_WXSTC
+	use_stc = false;
+#endif
 }
 
 TextSelectionController::~TextSelectionController() {
 #ifdef WITH_WXSTC
-	if (ctrl_stc) ctrl_stc->Unbind(wxEVT_STC_UPDATEUI, &TextSelectionController::UpdateUI, this);
+	if (ctrl_stc) {
+		ctrl_stc->Unbind(wxEVT_STC_UPDATEUI, &TextSelectionController::UpdateUI, this);
+	}
 #endif
-	if (ctrl_te) ctrl_te->Unbind(wxEVT_TEXT, &TextSelectionController::UpdateUI, this);
+	if (ctrl_te) {
+		ctrl_te->Unbind(wxEVT_KEY_UP, &TextSelectionController::UpdateUI, this);
+		ctrl_te->Unbind(wxEVT_LEFT_UP, &TextSelectionController::UpdateUI, this);
+	}
 }
 
-#define GET(var, new_value) do { \
-	long tmp = new_value;      \
-	if (tmp != var) {         \
-		var = tmp;            \
-		changed = true;       \
-	}                         \
-} while(false)
-
-#define SET(var, new_value) do { \
-	if (var != new_value) {              \
-		var = new_value;                 \
-		if (ctrl_te) ctrl_te->SetSelection(var, var); \
-		if (ctrl_stc) ctrl_stc->SetCurrentPos(var); \
-	}                                    \
-} while (false)
-
-void TextSelectionController::UpdateUI(wxEvent &evt) {
+void TextSelectionController::UpdateUI(wxEvent& evt) {
+	evt.Skip();
 	if (changing) return;
 
 	bool changed = false;
+	long tmp_insertion = 0, tmp_start = 0, tmp_end = 0;
 #ifdef WITH_WXSTC
 	if (use_stc && ctrl_stc) {
-		insertion_point = ctrl_stc->GetCurrentPos();
-		selection_start = ctrl_stc->GetSelectionStart();
-		selection_end = ctrl_stc->GetSelectionEnd();
-	} else
+		tmp_insertion = ctrl_stc->GetCurrentPos();
+		tmp_start = ctrl_stc->GetSelectionStart();
+		tmp_end = ctrl_stc->GetSelectionEnd();
+	}
+	else
 #endif
 	if (ctrl_te) {
-		insertion_point = ctrl_te->GetInsertionPoint();
-		selection_start = ctrl_te->GetInsertionPoint();
-		selection_end = ctrl_te->GetInsertionPoint();
+		tmp_insertion = ctrl_te->GetInsertionPoint();
+		ctrl_te->GetSelection(&tmp_start, &tmp_end);
+		// GetSelection returned by wxTextCtrl is the index of Unicode codepoint position
+		// We need to convert it to UTF-8 location
+		tmp_insertion = ctrl_te->GetRange(0, tmp_insertion).utf8_str().length();
+		tmp_start = ctrl_te->GetRange(0, tmp_start).utf8_str().length();
+		tmp_end = ctrl_te->GetRange(0, tmp_end).utf8_str().length();
 	}
-	AnnounceSelectionChanged();
+	if (tmp_insertion != insertion_point || tmp_start != selection_start || tmp_end != selection_end) {
+		insertion_point = tmp_insertion;
+		selection_start = tmp_start;
+		selection_end = tmp_end;
+		changed = true;
+	}
+	if (changed) AnnounceSelectionChanged();
 }
 
 void TextSelectionController::SetInsertionPoint(long position) {
 	changing = true;
+	if (insertion_point != position) {
+		insertion_point = position;
+		if (ctrl_stc || ctrl_te) {
 #ifdef WITH_WXSTC
-	if (use_stc && ctrl_stc) {
-		ctrl_stc->SetCurrentPos(position);
-	} else
+			if (use_stc && ctrl_stc) {
+				// STC uses byte positions directly
+				ctrl_stc->SetCurrentPos(position);
+				ctrl_stc->SetAnchor(position);
+			}
+			else
 #endif
-	if (ctrl_te) {
-		ctrl_te->SetInsertionPoint(position);
+			if (ctrl_te) {
+				// Convert UTF-8 position to wxTextEdit position
+				long tmp_position = 0;
+				long last_position = ctrl_te->GetLastPosition();
+				for (; tmp_position < last_position; ++tmp_position) {
+					if (ctrl_te->GetRange(0, tmp_position).utf8_str().length() >= position) {
+						break;
+					}
+				}
+				ctrl_te->SetInsertionPoint(tmp_position);
+			}
+		}
 	}
-	insertion_point = position;
 	changing = false;
 	AnnounceSelectionChanged();
 }
 
 void TextSelectionController::SetSelection(long start, long end) {
 	changing = true;
+	if (selection_start != start || selection_end != end) {
+		selection_start = start;
+		selection_end = end;
+		if (ctrl_stc || ctrl_te) {
 #ifdef WITH_WXSTC
-	if (use_stc && ctrl_stc) {
-		ctrl_stc->SetSelection(start, end);
-	} else
+			if (use_stc && ctrl_stc) {
+				ctrl_stc->SetSelection(start, end);
+			}
+			else
 #endif
-	if (ctrl_te) {
-		ctrl_te->SetSelection(start, end);
+			if (ctrl_te) {
+				long tmp_start = -1, tmp_end = -1;
+				// Convert UTF-8 position to wxTextEdit position
+				long last_position = ctrl_te->GetLastPosition();
+				for (long pos = 0; pos < last_position; ++pos) {
+					size_t pos_utf8 = ctrl_te->GetRange(0, pos).utf8_str().length();
+					if (tmp_start == -1 && pos_utf8 >= start) {
+						tmp_start = pos;
+					}
+					if (tmp_end == -1 && pos_utf8 >= end) {
+						tmp_end = pos;
+					}
+					if (tmp_start != -1 && tmp_end != -1) {
+						break;
+					}
+				}
+				if (tmp_start == -1) tmp_start = last_position;
+				if (tmp_end == -1) tmp_end = last_position;
+				ctrl_te->SetSelection(tmp_start, tmp_end);
+			}
+		}
 	}
-	selection_start = start;
-	selection_end = end;
 	changing = false;
 	AnnounceSelectionChanged();
 }

--- a/src/text_selection_controller.cpp
+++ b/src/text_selection_controller.cpp
@@ -16,60 +16,90 @@
 
 #include "text_selection_controller.h"
 
+#ifdef WITH_WXSTC
 #include <wx/stc/stc.h>
+#endif
+#include <wx/textctrl.h>
 
-void TextSelectionController::SetControl(wxStyledTextCtrl *ctrl) {
-	this->ctrl = ctrl;
-	if (ctrl)
-		ctrl->Bind(wxEVT_STC_UPDATEUI, &TextSelectionController::UpdateUI, this);
+#ifdef WITH_WXSTC
+void TextSelectionController::SetControl(wxStyledTextCtrl* ctrl) {
+	ctrl_stc = ctrl;
+}
+#endif
+
+void TextSelectionController::SetControl(wxTextCtrl* ctrl) {
+	ctrl_te = ctrl;
 }
 
 TextSelectionController::~TextSelectionController() {
-	if (ctrl) ctrl->Unbind(wxEVT_STC_UPDATEUI, &TextSelectionController::UpdateUI, this);
+#ifdef WITH_WXSTC
+	if (ctrl_stc) ctrl_stc->Unbind(wxEVT_STC_UPDATEUI, &TextSelectionController::UpdateUI, this);
+#endif
+	if (ctrl_te) ctrl_te->Unbind(wxEVT_TEXT, &TextSelectionController::UpdateUI, this);
 }
 
 #define GET(var, new_value) do { \
-	int tmp = new_value;      \
+	long tmp = new_value;      \
 	if (tmp != var) {         \
 		var = tmp;            \
 		changed = true;       \
 	}                         \
 } while(false)
 
-#define SET(var, new_value, Setter) do { \
+#define SET(var, new_value) do { \
 	if (var != new_value) {              \
 		var = new_value;                 \
-		if (ctrl) ctrl->Setter(var);     \
+		if (ctrl_te) ctrl_te->SetSelection(var, var); \
+		if (ctrl_stc) ctrl_stc->SetCurrentPos(var); \
 	}                                    \
 } while (false)
 
-void TextSelectionController::UpdateUI(wxStyledTextEvent &evt) {
+void TextSelectionController::UpdateUI(wxEvent &evt) {
 	if (changing) return;
 
 	bool changed = false;
-	GET(insertion_point, ctrl->GetInsertionPoint());
-	if (evt.GetUpdated() & wxSTC_UPDATE_SELECTION) {
-		GET(selection_start, ctrl->GetSelectionStart());
-		GET(selection_end, ctrl->GetSelectionEnd());
+#ifdef WITH_WXSTC
+	if (use_stc && ctrl_stc) {
+		insertion_point = ctrl_stc->GetCurrentPos();
+		selection_start = ctrl_stc->GetSelectionStart();
+		selection_end = ctrl_stc->GetSelectionEnd();
+	} else
+#endif
+	if (ctrl_te) {
+		insertion_point = ctrl_te->GetInsertionPoint();
+		selection_start = ctrl_te->GetInsertionPoint();
+		selection_end = ctrl_te->GetInsertionPoint();
 	}
-	else {
-		GET(selection_start, insertion_point);
-		GET(selection_end, insertion_point);
-	}
-	if (changed) AnnounceSelectionChanged();
+	AnnounceSelectionChanged();
 }
 
-void TextSelectionController::SetInsertionPoint(int position) {
+void TextSelectionController::SetInsertionPoint(long position) {
 	changing = true;
-	SET(insertion_point, position, SetInsertionPoint);
+#ifdef WITH_WXSTC
+	if (use_stc && ctrl_stc) {
+		ctrl_stc->SetCurrentPos(position);
+	} else
+#endif
+	if (ctrl_te) {
+		ctrl_te->SetInsertionPoint(position);
+	}
+	insertion_point = position;
 	changing = false;
 	AnnounceSelectionChanged();
 }
 
-void TextSelectionController::SetSelection(int start, int end) {
+void TextSelectionController::SetSelection(long start, long end) {
 	changing = true;
-	SET(selection_start, start, SetSelectionStart);
-	SET(selection_end, end, SetSelectionEnd);
+#ifdef WITH_WXSTC
+	if (use_stc && ctrl_stc) {
+		ctrl_stc->SetSelection(start, end);
+	} else
+#endif
+	if (ctrl_te) {
+		ctrl_te->SetSelection(start, end);
+	}
+	selection_start = start;
+	selection_end = end;
 	changing = false;
 	AnnounceSelectionChanged();
 }

--- a/src/text_selection_controller.cpp
+++ b/src/text_selection_controller.cpp
@@ -24,6 +24,13 @@
 #ifdef WITH_WXSTC
 void TextSelectionController::SetControl(wxStyledTextCtrl* ctrl) {
 	ctrl_stc = ctrl;
+	ctrl_te = nullptr;
+	if (ctrl) {
+		ctrl->Bind(wxEVT_STC_UPDATEUI, &TextSelectionController::UpdateUI, this);
+	}
+#ifdef WITH_WXSTC
+	use_stc = true;
+#endif
 }
 #endif
 

--- a/src/text_selection_controller.h
+++ b/src/text_selection_controller.h
@@ -17,19 +17,25 @@
 #include <libaegisub/signal.h>
 
 class wxStyledTextCtrl;
-class wxStyledTextEvent;
+class wxTextCtrl;
+class wxEvent;
 
 class TextSelectionController {
-	int selection_start = 0;
-	int selection_end = 0;
-	int insertion_point = 0;
+	long selection_start = 0;
+	long selection_end = 0;
+	long insertion_point = 0;
 	bool changing = false;
 
-	int staged_selection_start = 0;
-	int staged_selection_end = 0;
+	long staged_selection_start = 0;
+	long staged_selection_end = 0;
 	bool has_staged_selection = false;
 
-	wxStyledTextCtrl *ctrl = nullptr;
+	// Pointers to the current controls (either wxStyledTextCtrl or wxTextCtrl)
+	wxStyledTextCtrl *ctrl_stc = nullptr;
+	wxTextCtrl *ctrl_te = nullptr;
+#ifdef WITH_WXSTC
+	bool use_stc = true;
+#endif
 
 	void UpdateUI(wxStyledTextEvent &evt);
 
@@ -43,21 +49,21 @@ public:
 	// This is useful when one is still waiting on other changes to be applied, but already listening for changes to the
 	// selection in the eventually visible text.
 	// They also provide a wrapper for setting a selection whose insertion point is on the left side.
-	void StageSetSelection(int start, int end) { staged_selection_start = start; staged_selection_end = end; has_staged_selection = true; };
-	void StageSetInsertionPoint(int point) { StageSetSelection(point, point); };
+	void StageSetSelection(long start, long end) { staged_selection_start = start; staged_selection_end = end; has_staged_selection = true; };
+	void StageSetInsertionPoint(long point) { StageSetSelection(point, point); };
 	void CommitStagedChanges();
 	void DropStagedChanges() { has_staged_selection = false; };
 
-	int GetSelectionStart() const { return selection_start; }
-	int GetSelectionEnd() const { return selection_end; }
-	int GetInsertionPoint() const { return insertion_point; }
+	long GetSelectionStart() const { return selection_start; }
+	long GetSelectionEnd() const { return selection_end; }
+	long GetInsertionPoint() const { return insertion_point; }
 
-	int GetStagedSelectionStart() const { return has_staged_selection ? staged_selection_start : selection_start; }
-	int GetStagedSelectionEnd() const { return has_staged_selection ? staged_selection_end : selection_end; }
-	int GetStagedInsertionPoint() const { return has_staged_selection ? staged_selection_end : insertion_point; }
+	long GetStagedSelectionStart() const { return has_staged_selection ? staged_selection_start : selection_start; }
+	long GetStagedSelectionEnd() const { return has_staged_selection ? staged_selection_end : selection_end; }
+	long GetStagedInsertionPoint() const { return has_staged_selection ? staged_selection_end : insertion_point; }
 
-	void SetControl(wxStyledTextCtrl *ctrl);
-	wxStyledTextCtrl* GetControl() const { return ctrl; }
+	void SetControl(wxStyledTextCtrl* ctrl);
+	void SetControl(wxTextCtrl* ctrl);
 	~TextSelectionController();
 
 	DEFINE_SIGNAL_ADDERS(AnnounceSelectionChanged, AddSelectionListener)

--- a/src/text_selection_controller.h
+++ b/src/text_selection_controller.h
@@ -16,8 +16,10 @@
 
 #include <libaegisub/signal.h>
 
-class wxStyledTextCtrl;
-class wxTextCtrl;
+#include <wx/stc/stc.h>
+#include <wx/textctrl.h>
+
+class wxStyledTextEvent;
 class wxEvent;
 
 class TextSelectionController {
@@ -61,6 +63,9 @@ public:
 	long GetStagedSelectionStart() const { return has_staged_selection ? staged_selection_start : selection_start; }
 	long GetStagedSelectionEnd() const { return has_staged_selection ? staged_selection_end : selection_end; }
 	long GetStagedInsertionPoint() const { return has_staged_selection ? staged_selection_end : insertion_point; }
+
+	wxStyledTextCtrl *GetControl() const { return ctrl_stc; }
+	wxTextCtrl *GetTextControl() const { return ctrl_te; }
 
 	void SetControl(wxStyledTextCtrl* ctrl);
 	void SetControl(wxTextCtrl* ctrl);

--- a/src/text_selection_controller.h
+++ b/src/text_selection_controller.h
@@ -39,13 +39,13 @@ class TextSelectionController {
 	bool use_stc = true;
 #endif
 
-	void UpdateUI(wxStyledTextEvent &evt);
+	void UpdateUI(wxEvent &evt);
 
 	agi::signal::Signal<> AnnounceSelectionChanged;
 
 public:
-	void SetSelection(int start, int end);
-	void SetInsertionPoint(int point);
+	void SetSelection(long start, long end);
+	void SetInsertionPoint(long point);
 
 	// This set of functions allows staging changes to the selection or insertion points, which can then be applied later.
 	// This is useful when one is still waiting on other changes to be applied, but already listening for changes to the

--- a/src/ui_numeric_slider.cpp
+++ b/src/ui_numeric_slider.cpp
@@ -282,7 +282,7 @@ private:
             if (std::abs(cfg.presets[i]-value) < 0.0001)
                 menu.Check(id,true);
 
-            menu.Bind(wxEVT_MENU,[=](wxCommandEvent&)
+            menu.Bind(wxEVT_MENU,[=, this](wxCommandEvent&)
             {
                 SetValue(cfg.presets[i]);
             }, id);

--- a/tools/version.ps1
+++ b/tools/version.ps1
@@ -30,6 +30,10 @@ if ([System.IO.Path]::GetFullPath([System.IO.Path]::Combine((pwd).Path, $BuildRo
 $gitVersionHeaderPath = Join-Path $BuildRoot 'git_version.h'
 
 $version = @{}
+$version['TAGGED_RELEASE'] = $false
+$version['RESOURCE_BASE_VERSION'] = @(0, 0, 0)
+$version['INSTALLER_VERSION'] = '0.0.0'
+
 if (Test-Path $gitVersionHeaderPath) {
   Get-Content $gitVersionHeaderPath | %{$_.Trim()} | ?{$_} | %{
     switch -regex ($_) {

--- a/tools/version.ps1
+++ b/tools/version.ps1
@@ -10,6 +10,7 @@ param (
 $lastSvnRevision = 6962
 $lastSvnHash = '16cd907fe7482cb54a7374cd28b8501f138116be'
 $defineNumberMatch = [regex] '^#define\s+(\w+)\s+(\d+)$'
+$defineResourceBaseVersionMatch = [regex] '^#define\s+RESOURCE_BASE_VERSION\s*\(?\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)?\s*$'
 $defineStringMatch = [regex] "^#define\s+(\w+)\s+[`"']?(.+?)[`"']?$"
 $semVerMatch = [regex] '^v?(\d+)\.(\d+)(?:\.(\d+))?(?:-(\w+))?$'
 
@@ -29,11 +30,11 @@ if ([System.IO.Path]::GetFullPath([System.IO.Path]::Combine((pwd).Path, $BuildRo
   }
 $gitVersionHeaderPath = Join-Path $BuildRoot 'git_version.h'
 
-$version = @{}
-$version['TAGGED_RELEASE'] = $false
-$version['RESOURCE_BASE_VERSION'] = @(0, 0, 0)
-$version['INSTALLER_VERSION'] = '0.0.0'
-
+$version = @{
+  TAGGED_RELEASE = $false
+  INSTALLER_VERSION = '0.0.0'
+  RESOURCE_BASE_VERSION = @(0, 0, 0)
+}
 if (Test-Path $gitVersionHeaderPath) {
   Get-Content $gitVersionHeaderPath | %{$_.Trim()} | ?{$_} | %{
     switch -regex ($_) {


### PR DESCRIPTION
### Major updates

- **New Subtitle Edit Control:** Added a new STC-based subtitle edit control implementation (optional `USE STC`).
- **RTL & Layout Improvements:** Improved Right-to-Left (RTL) handling. On Ubuntu and macOS, the application now supports automatic RTL layout switching (via wxWidgets native detection).
- **RTL/LTR Toggles:** Added menu items, keyboard shortcuts, and a context-menu toggle to switch RTL/LTR modes. **Note:** The toggle updates **both** the subtitle grid and the edit box simultaneously.

### Added

- `src/subs_edit_ctrl_stc.h`, `src/subs_edit_ctrl_stc.cpp` — New STC subtitle edit control implementation (wxStyledTextCtrl-based).
  - New menu items and keyboard shortcuts for toggling RTL/LTR (updates Grid and Edit Box).
  - Right-click context menu entries to toggle RTL/LTR in the subtitle edit box.
- **Auto-detection:** Support for wxWidgets-based RTL auto-detection on Ubuntu & macOS (applied to both Native and STC controls).
- **Spellchecker:** Features added/surfaced for native wxTextCtrl.

### Changed

- `src/subs_edit_box.cpp` / `.h` — Subtitle edit box logic updated to support new controls, context menu, and synchronized RTL toggles for the grid.
- `src/subs_edit_ctrl.cpp` / `.h` — Core subtitle edit control modifications to support both native and STC modes.
- `src/text_selection_controller.cpp` / `.h` — Selection behavior updates and integration with new edit controls.
- `src/dialog_translation.cpp` / `.h`  — Improved translation dialog behavior/UX.
- `src/command/edit.cpp` — Edit command modifications to accommodate the new editing flows and simultaneous Grid/Editor toggling.

### Build / CI

- `.github/workflows/ci.yml` — CI updated and adjust Ubuntu/MSVC workflows.
- `meson.build`, `meson_options.txt`, `src/meson.build` — Meson configuration changes and added build options (wxstc/related flags).

### Defaults & Preferences

- `src/preferences.cpp`
- `src/libresrc/osx/default_config.json`
- `src/libresrc/default_config.json`
- `src/libresrc/default_menu.json`
- `src/libresrc/default_menu_platform.json`

  - Default config/preferences refreshed to reflect new controls and RTL options.

### Platform / OS-specific

- Added `src/osx/scintilla_ime.mm` & `scintilla_ime.mm` — Input handling tweaks for macOS.

### Tests / Libraries

- `tools/version.ps1` & `win-installer-setup.ps1` — Updated or added filesystem test(s).
- `src/auto4_lua.cpp` & `dialog_fontpicker.cpp` & `ui_numeric_slider.cpp` — Updated.

### Notable Behavior / UX Details & Known Limitations

**RTL & Auto-detection**
- **Windows:** wxWidgets does **not** auto-detect RTL. You must manually toggle RTL mode via the Edit menu, keyboard shortcut, or context menu.
- **Ubuntu/macOS:** wxWidgets automatically detects RTL text. The application will auto-switch the layout for both the Editor and the Grid.
- **Sync:** Toggling RTL (manually or via auto-detect) updates both the **Subtitle Grid** and the **Edit Box**.

**Comparison: Native vs. STC**

| Feature | Native `wxTextCtrl` | STC (`wxStyledTextCtrl`) |
| :--- | :--- | :--- |
| **RTL Rendering** | ✅ Full Support | ✅ Supported |
| **Arrow Navigation** | ✅ Correct | ⚠️ **Reversed** (Right arrow moves cursor left) |
| **Tag Coloring** | ❌ No | ✅ **Yes** (Aegisub syntax highlighting) |
| **Spellchecker** | ⚠️ Functional (visual differs) | ✅ Accurate underlines |
| **RTL Auto-detect** | ✅ Yes (Ubuntu/macOS only) | ✅ Yes (Ubuntu/macOS only) |

**Summary Guidance**
- **Use Native `wxTextCtrl` if:** You need robust RTL arrow key navigation and correct cursor movement.
- **Use STC if:** You need Aegisub tag coloring and accurate spellchecker visuals, and are willing to tolerate reversed arrow key navigation in RTL mode.