### PR TITLE
feat(ai): make OpenAI API base URL configurable

### DIFF
--- a/po/aegisub.pot
+++ b/po/aegisub.pot
@@ -10742,3 +10742,7 @@ msgstr ""
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr ""
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr ""

--- a/po/aegisub.pot
+++ b/po/aegisub.pot
@@ -10738,3 +10738,7 @@ msgstr ""
 #: packages/win_installer/fragment_strings.iss:1
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code."
 msgstr ""
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr ""

--- a/po/aegisub.pot
+++ b/po/aegisub.pot
@@ -10739,10 +10739,10 @@ msgstr ""
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code."
 msgstr ""
 
-#: src/dialog_ai_connection.cpp
+#: ../src/dialog_ai_connection.cpp:209
 msgid "API base URL:"
 msgstr ""
 
-#: ../src/dialog_ai_connection.cpp:214
+#: ../src/dialog_ai_connection.cpp:215
 msgid "Changing this could cause issues."
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -11856,3 +11856,7 @@ msgstr "البحث عن التحديثات:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "سيقوم برنامج التثبيت الآن بتثبيت الإصدار {#BUILD_GIT_VERSION_STRING} من Aegisub على جهاز الكمبيوتر لديك.%n%nيحمي برنامج Aegisub اتفاقية ترخيص GNU General Public License version 2. وهذا يعني أنه يمكنك استخدام البرنامج مجانًا، ولكن المطورين لا يقدمون أي ضمانات بشأن تشغيل البرنامج.%n%nلمزيد من المعلومات، يُرجى زيارة موقع Aegisub الإلكتروني، حيث يمكنك، من بين أمور أخرى، الحصول على التعليمات البرمجية المصدرية للبرنامج."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "عنوان URL الأساسي لواجهة API:"

--- a/po/ar.po
+++ b/po/ar.po
@@ -11860,3 +11860,7 @@ msgstr "سيقوم برنامج التثبيت الآن بتثبيت الإصد�
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "عنوان URL الأساسي لواجهة API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "قد يؤدي تغيير هذا إلى حدوث مشكلات."

--- a/po/ar.po
+++ b/po/ar.po
@@ -11861,6 +11861,6 @@ msgstr "سيقوم برنامج التثبيت الآن بتثبيت الإصد�
 msgid "API base URL:"
 msgstr "عنوان URL الأساسي لواجهة API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "قد يؤدي تغيير هذا إلى حدوث مشكلات."

--- a/po/be.po
+++ b/po/be.po
@@ -11972,3 +11972,7 @@ msgstr "Праверка абнаўленняў:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Праграма ўстаноўкі зараз усталюе на ваш камп'ютар Aegisub версіі {#BUILD_GIT_VERSION_STRING}.%n%nПраграма Aegisub распаўсюджваецца паводле ліцэнзіі GNU General Public License version 2. Гэта азначае, што вы можаце бясплатна карыстацца праграмай, аднак распрацоўшчыкі не даюць ніякіх гарантый адносна яе працы.%n%nДля атрымання дадатковай інфармацыі наведайце вэб-сайт Aegisub, дзе таксама можна атрымаць зыходны код праграмы."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "Базавы URL API:"

--- a/po/be.po
+++ b/po/be.po
@@ -11976,3 +11976,7 @@ msgstr "Праграма ўстаноўкі зараз усталюе на ва�
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "Базавы URL API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Змяненне гэтага параметра можа выклікаць праблемы."

--- a/po/be.po
+++ b/po/be.po
@@ -11977,6 +11977,6 @@ msgstr "Праграма ўстаноўкі зараз усталюе на ва�
 msgid "API base URL:"
 msgstr "Базавы URL API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Змяненне гэтага параметра можа выклікаць праблемы."

--- a/po/bg.po
+++ b/po/bg.po
@@ -11980,3 +11980,7 @@ msgstr "Инсталационната програма ще инсталира 
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "Базов URL на API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Промяната на това може да причини проблеми."

--- a/po/bg.po
+++ b/po/bg.po
@@ -11976,3 +11976,7 @@ msgstr "Проверка за актуализации:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Инсталационната програма ще инсталира версията на Aegisub {#BUILD_GIT_VERSION_STRING} на Вашия компютър.%n%nПрограмата Aegisub се разпространява съгласно лиценза GNU General Public License version 2. Това означава, че можете да използвате програмата безплатно, но разработчиците не поемат никаква гаранция за работата ѝ.%n%nЗа повече информация посетете уебсайта на Aegisub, където можете, наред с другото, да получите изходния код на програмата."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "Базов URL на API:"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11981,6 +11981,6 @@ msgstr "Инсталационната програма ще инсталира 
 msgid "API base URL:"
 msgstr "Базов URL на API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Промяната на това може да причини проблеми."

--- a/po/ca.po
+++ b/po/ca.po
@@ -12029,3 +12029,7 @@ msgstr "Comprova si hi ha actualitzacions:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "L’instal·lador instal·larà ara la versió {#BUILD_GIT_VERSION_STRING} d’Aegisub a l’ordinador.%n%nEl programa Aegisub està protegit per la llicència GNU General Public License versió 2. Això significa que podeu utilitzar el programa gratuïtament, però els desenvolupadors no ofereixen cap garantia sobre el funcionament del programa.%n%nPer obtenir més informació, visiteu el lloc web d’Aegisub, on també podeu obtenir el codi font del programa."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "URL base de l'API:"

--- a/po/ca.po
+++ b/po/ca.po
@@ -12034,6 +12034,6 @@ msgstr "L’instal·lador instal·larà ara la versió {#BUILD_GIT_VERSION_STRIN
 msgid "API base URL:"
 msgstr "URL base de l'API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Canviar això pot causar problemes."

--- a/po/ca.po
+++ b/po/ca.po
@@ -12033,3 +12033,7 @@ msgstr "L’instal·lador instal·larà ara la versió {#BUILD_GIT_VERSION_STRIN
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "URL base de l'API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Canviar això pot causar problemes."

--- a/po/cs.po
+++ b/po/cs.po
@@ -11903,6 +11903,6 @@ msgstr "Instalátor nyní nainstaluje do počítače Aegisub {#BUILD_GIT_VERSION
 msgid "API base URL:"
 msgstr "Základní URL API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Změna tohoto nastavení může způsobit problémy."

--- a/po/cs.po
+++ b/po/cs.po
@@ -11902,3 +11902,7 @@ msgstr "Instalátor nyní nainstaluje do počítače Aegisub {#BUILD_GIT_VERSION
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "Základní URL API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Změna tohoto nastavení může způsobit problémy."

--- a/po/cs.po
+++ b/po/cs.po
@@ -11898,3 +11898,7 @@ msgstr "Kontrola aktualizací:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Instalátor nyní nainstaluje do počítače Aegisub {#BUILD_GIT_VERSION_STRING}.%n%nProgram Aegisub je chráněn licenční smlouvou GNU General Public License version 2. To znamená, že program můžete používat zdarma, vývojáři však neposkytují na jeho fungování žádnou záruku.%n%nDalší informace najdete na webových stránkách Aegisub, kde můžete mimo jiné získat zdrojový kód programu."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "Základní URL API:"

--- a/po/da.po
+++ b/po/da.po
@@ -11836,3 +11836,7 @@ msgstr "Installationsprogrammet vil nu installere Aegisub {#BUILD_GIT_VERSION_ST
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "API-basis-URL:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Ændring af dette kan medføre problemer."

--- a/po/da.po
+++ b/po/da.po
@@ -11832,3 +11832,7 @@ msgstr "Søger efter opdateringer:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Installationsprogrammet vil nu installere Aegisub {#BUILD_GIT_VERSION_STRING} på din computer.%n%nAegisub er licenseret under GNU General Public License version 2. Det betyder, at du må bruge programmet gratis, men udviklerne påtager sig intet ansvar for programmets funktion.%n%nDu kan finde flere oplysninger på Aegisubs websted, hvor du blandt andet kan hente programmets kildekode."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "API-basis-URL:"

--- a/po/da.po
+++ b/po/da.po
@@ -11837,6 +11837,6 @@ msgstr "Installationsprogrammet vil nu installere Aegisub {#BUILD_GIT_VERSION_ST
 msgid "API base URL:"
 msgstr "API-basis-URL:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Ændring af dette kan medføre problemer."

--- a/po/de.po
+++ b/po/de.po
@@ -11990,6 +11990,6 @@ msgstr "Der Installer wird jetzt Aegisub Version {#BUILD_GIT_VERSION_STRING} auf
 msgid "API base URL:"
 msgstr "API-Basis-URL:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Das Ändern dieser Einstellung kann zu Problemen führen."

--- a/po/de.po
+++ b/po/de.po
@@ -11985,3 +11985,7 @@ msgstr "Nach Updates suchen:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Der Installer wird jetzt Aegisub Version {#BUILD_GIT_VERSION_STRING} auf Ihrem Computer installieren.%n%nAegisub steht unter der GNU General Public License Version 2. Das bedeutet, dass Sie das Programm kostenlos verwenden können, die Entwickler jedoch keinerlei Garantie für die Funktion des Programms übernehmen.%n%nWeitere Informationen finden Sie auf der Aegisub-Website, wo Sie unter anderem den Quellcode des Programms herunterladen können."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "API-Basis-URL:"

--- a/po/de.po
+++ b/po/de.po
@@ -11989,3 +11989,7 @@ msgstr "Der Installer wird jetzt Aegisub Version {#BUILD_GIT_VERSION_STRING} auf
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "API-Basis-URL:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Das Ändern dieser Einstellung kann zu Problemen führen."

--- a/po/el.po
+++ b/po/el.po
@@ -12032,3 +12032,7 @@ msgstr "Το πρόγραμμα εγκατάστασης θα εγκαταστή
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "Βασικό URL API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Η αλλαγή αυτής της ρύθμισης μπορεί να προκαλέσει προβλήματα."

--- a/po/el.po
+++ b/po/el.po
@@ -12033,6 +12033,6 @@ msgstr "Το πρόγραμμα εγκατάστασης θα εγκαταστή
 msgid "API base URL:"
 msgstr "Βασικό URL API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Η αλλαγή αυτής της ρύθμισης μπορεί να προκαλέσει προβλήματα."

--- a/po/el.po
+++ b/po/el.po
@@ -12028,3 +12028,7 @@ msgstr "Έλεγχος για ενημερώσεις:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Το πρόγραμμα εγκατάστασης θα εγκαταστήσει τώρα την έκδοση Aegisub {#BUILD_GIT_VERSION_STRING} στον υπολογιστή σας.%n%nΤο πρόγραμμα Aegisub διανέμεται υπό τους όρους της άδειας GNU General Public License version 2. Αυτό σημαίνει ότι μπορείτε να χρησιμοποιείτε το πρόγραμμα δωρεάν, αλλά οι προγραμματιστές δεν παρέχουν καμία εγγύηση για τη λειτουργία του.%n%nΓια περισσότερες πληροφορίες, επισκεφθείτε τον ιστότοπο του Aegisub, όπου μπορείτε, μεταξύ άλλων, να αποκτήσετε τον πηγαίο κώδικα του προγράμματος."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "Βασικό URL API:"

--- a/po/es.po
+++ b/po/es.po
@@ -12029,6 +12029,6 @@ msgstr "El instalador instalará ahora en su ordenador la versión {#BUILD_GIT_V
 msgid "API base URL:"
 msgstr "URL base de la API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Cambiar esto puede causar problemas."

--- a/po/es.po
+++ b/po/es.po
@@ -12028,3 +12028,7 @@ msgstr "El instalador instalará ahora en su ordenador la versión {#BUILD_GIT_V
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "URL base de la API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Cambiar esto puede causar problemas."

--- a/po/es.po
+++ b/po/es.po
@@ -12024,3 +12024,7 @@ msgstr "Buscar actualizaciones:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "El instalador instalará ahora en su ordenador la versión {#BUILD_GIT_VERSION_STRING} de Aegisub.%n%nAegisub está protegido por la licencia GNU General Public License versión 2. Esto significa que puede utilizar el programa de forma gratuita, pero los desarrolladores no ofrecen ninguna garantía sobre su funcionamiento.%n%nPara obtener más información, visite el sitio web de Aegisub, donde también podrá obtener el código fuente del programa."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "URL base de la API:"

--- a/po/eu.po
+++ b/po/eu.po
@@ -11972,3 +11972,7 @@ msgstr "Instalatzaileak Aegisub {#BUILD_GIT_VERSION_STRING} bertsioa instalatuko
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "APIaren oinarrizko URLa:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Hau aldatzeak arazoak sor ditzake."

--- a/po/eu.po
+++ b/po/eu.po
@@ -11973,6 +11973,6 @@ msgstr "Instalatzaileak Aegisub {#BUILD_GIT_VERSION_STRING} bertsioa instalatuko
 msgid "API base URL:"
 msgstr "APIaren oinarrizko URLa:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Hau aldatzeak arazoak sor ditzake."

--- a/po/eu.po
+++ b/po/eu.po
@@ -11968,3 +11968,7 @@ msgstr "Eguneratzeak bilatzen:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Instalatzaileak Aegisub {#BUILD_GIT_VERSION_STRING} bertsioa instalatuko du orain zure ordenagailuan.%n%nAegisub programa GNU General Public License version 2 lizentzia-kontratuak babesten du. Horrek esan nahi du programa doan erabil dezakezula, baina garatzaileek ez dutela programaren funtzionamenduaren inolako bermerik ematen.%n%nInformazio gehiago lortzeko, joan Aegisub webgunera; bertan, besteak beste, programaren iturburu-kodea eskuratu ahal izango duzu."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "APIaren oinarrizko URLa:"

--- a/po/fa.po
+++ b/po/fa.po
@@ -11803,3 +11803,7 @@ msgstr "بررسی به‌روزرسانی‌ها:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "برنامهٔ نصب اکنون نسخهٔ Aegisub {#BUILD_GIT_VERSION_STRING} را روی رایانهٔ شما نصب خواهد کرد.%n%nنرم‌افزار Aegisub تحت مجوز GNU General Public License version 2 منتشر می‌شود. این بدان معناست که می‌توانید از برنامه به‌صورت رایگان استفاده کنید، اما توسعه‌دهندگان هیچ‌گونه ضمانتی دربارهٔ عملکرد برنامه ارائه نمی‌دهند.%n%nبرای اطلاعات بیشتر، به وب‌سایت Aegisub مراجعه کنید؛ در آنجا می‌توانید، از جمله، کد منبع برنامه را دریافت کنید."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "نشانی پایهٔ API:"

--- a/po/fa.po
+++ b/po/fa.po
@@ -11808,6 +11808,6 @@ msgstr "برنامهٔ نصب اکنون نسخهٔ Aegisub {#BUILD_GIT_VERSION_
 msgid "API base URL:"
 msgstr "نشانی پایهٔ API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "تغییر این مورد ممکن است باعث بروز مشکل شود."

--- a/po/fa.po
+++ b/po/fa.po
@@ -11807,3 +11807,7 @@ msgstr "برنامهٔ نصب اکنون نسخهٔ Aegisub {#BUILD_GIT_VERSION_
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "نشانی پایهٔ API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "تغییر این مورد ممکن است باعث بروز مشکل شود."

--- a/po/fi.po
+++ b/po/fi.po
@@ -12044,6 +12044,6 @@ msgstr "Asennusohjelma asentaa nyt Aegisub-version {#BUILD_GIT_VERSION_STRING} t
 msgid "API base URL:"
 msgstr "API:n perus-URL:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Tämän muuttaminen voi aiheuttaa ongelmia."

--- a/po/fi.po
+++ b/po/fi.po
@@ -12043,3 +12043,7 @@ msgstr "Asennusohjelma asentaa nyt Aegisub-version {#BUILD_GIT_VERSION_STRING} t
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "API:n perus-URL:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Tämän muuttaminen voi aiheuttaa ongelmia."

--- a/po/fi.po
+++ b/po/fi.po
@@ -12039,3 +12039,7 @@ msgstr "Päivitysten tarkistus:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Asennusohjelma asentaa nyt Aegisub-version {#BUILD_GIT_VERSION_STRING} tietokoneellesi.%n%nAegisub-ohjelmaa suojaa GNU General Public License version 2 -lisenssisopimus. Tämä tarkoittaa, että voit käyttää ohjelmaa maksutta, mutta kehittäjät eivät anna minkäänlaista takuuta ohjelman toiminnasta.%n%nLisätietoja saat Aegisubin verkkosivustolta, josta voit muun muassa hankkia ohjelman lähdekoodin."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "API:n perus-URL:"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -12014,3 +12014,7 @@ msgstr "Le programme d’installation va maintenant installer Aegisub version {#
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "URL de base de l’API :"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "La modification de ce paramètre peut entraîner des problèmes."

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -12015,6 +12015,6 @@ msgstr "Le programme d’installation va maintenant installer Aegisub version {#
 msgid "API base URL:"
 msgstr "URL de base de l’API :"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "La modification de ce paramètre peut entraîner des problèmes."

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -12010,3 +12010,7 @@ msgstr "Rechercher les mises à jour :"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Le programme d’installation va maintenant installer Aegisub version {#BUILD_GIT_VERSION_STRING} sur votre ordinateur.%n%nAegisub est distribué sous licence GNU General Public License version 2. Cela signifie que vous pouvez utiliser le programme gratuitement, mais que les développeurs ne fournissent aucune garantie quant à son fonctionnement.%n%nPour plus d’informations, consultez le site web d’Aegisub, où vous pourrez notamment obtenir le code source du programme."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "URL de base de l’API :"

--- a/po/gl.po
+++ b/po/gl.po
@@ -11913,6 +11913,6 @@ msgstr "O instalador instalará agora no seu ordenador a versión {#BUILD_GIT_VE
 msgid "API base URL:"
 msgstr "URL base da API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Cambiar isto pode causar problemas."

--- a/po/gl.po
+++ b/po/gl.po
@@ -11908,3 +11908,7 @@ msgstr "Buscar actualizacións:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "O instalador instalará agora no seu ordenador a versión {#BUILD_GIT_VERSION_STRING} de Aegisub.%n%nA aplicación Aegisub está protexida pola licenza GNU General Public License version 2. Isto significa que pode usar a aplicación de balde, pero os desenvolvedores non ofrecen ningunha garantía sobre o seu funcionamento.%n%nPara obter máis información, visite o sitio web de Aegisub, onde tamén poderá obter o código fonte da aplicación."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "URL base da API:"

--- a/po/gl.po
+++ b/po/gl.po
@@ -11912,3 +11912,7 @@ msgstr "O instalador instalará agora no seu ordenador a versión {#BUILD_GIT_VE
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "URL base da API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Cambiar isto pode causar problemas."

--- a/po/hu.po
+++ b/po/hu.po
@@ -12067,3 +12067,7 @@ msgstr ""
 
 #~ msgid "To"
 #~ msgstr "Vég"
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "API alap URL:"

--- a/po/hu.po
+++ b/po/hu.po
@@ -12068,10 +12068,10 @@ msgstr ""
 #~ msgid "To"
 #~ msgstr "Vég"
 
-#: src/dialog_ai_connection.cpp
+#: ../src/dialog_ai_connection.cpp:209
 msgid "API base URL:"
 msgstr "API alap URL:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: ../src/dialog_ai_connection.cpp:215
 msgid "Changing this could cause issues."
 msgstr "Ennek a módosítása problémákat okozhat."

--- a/po/hu.po
+++ b/po/hu.po
@@ -12071,3 +12071,7 @@ msgstr ""
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "API alap URL:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Ennek a módosítása problémákat okozhat."

--- a/po/id.po
+++ b/po/id.po
@@ -11944,3 +11944,7 @@ msgstr "Penginstal akan menginstal Aegisub versi {#BUILD_GIT_VERSION_STRING} ke 
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "URL dasar API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Mengubah ini dapat menyebabkan masalah."

--- a/po/id.po
+++ b/po/id.po
@@ -11940,3 +11940,7 @@ msgstr "Memeriksa pembaruan:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Penginstal akan menginstal Aegisub versi {#BUILD_GIT_VERSION_STRING} ke komputer Anda sekarang.%n%nProgram Aegisub dilindungi oleh perjanjian lisensi GNU General Public License versi 2. Artinya, Anda dapat menggunakan program ini secara gratis, tetapi pengembang tidak memberikan jaminan apa pun atas pengoperasian program.%n%nUntuk informasi lebih lanjut, kunjungi situs web Aegisub, tempat Anda juga dapat memperoleh kode sumber program."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "URL dasar API:"

--- a/po/id.po
+++ b/po/id.po
@@ -11945,6 +11945,6 @@ msgstr "Penginstal akan menginstal Aegisub versi {#BUILD_GIT_VERSION_STRING} ke 
 msgid "API base URL:"
 msgstr "URL dasar API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Mengubah ini dapat menyebabkan masalah."

--- a/po/it.po
+++ b/po/it.po
@@ -11912,3 +11912,7 @@ msgstr "Il programma di installazione installerà ora sul computer la versione {
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "URL di base dell'API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "La modifica di questa impostazione potrebbe causare problemi."

--- a/po/it.po
+++ b/po/it.po
@@ -11913,6 +11913,6 @@ msgstr "Il programma di installazione installerà ora sul computer la versione {
 msgid "API base URL:"
 msgstr "URL di base dell'API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "La modifica di questa impostazione potrebbe causare problemi."

--- a/po/it.po
+++ b/po/it.po
@@ -11908,3 +11908,7 @@ msgstr "Ricerca aggiornamenti:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Il programma di installazione installerà ora sul computer la versione {#BUILD_GIT_VERSION_STRING} di Aegisub.%n%nAegisub è distribuito secondo i termini della GNU General Public License versione 2. Ciò significa che è possibile utilizzare il programma gratuitamente, ma gli sviluppatori non forniscono alcuna garanzia sul suo funzionamento.%n%nPer ulteriori informazioni, visitare il sito web di Aegisub, dove è possibile anche ottenere il codice sorgente del programma."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "URL di base dell'API:"

--- a/po/ja.po
+++ b/po/ja.po
@@ -11827,3 +11827,7 @@ msgstr "更新を確認中："
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "このインストーラーは、Aegisub {#BUILD_GIT_VERSION_STRING} をコンピューターにインストールします。%n%nAegisub は GNU General Public License version 2 ライセンスの下で提供されています。これは、プログラムを無料で使用できる一方、開発者はプログラムの動作について一切保証しないことを意味します。%n%n詳細については Aegisub のウェブサイトをご覧ください。ソースコードなどを入手できます。"
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "API ベース URL:"

--- a/po/ja.po
+++ b/po/ja.po
@@ -11831,3 +11831,7 @@ msgstr "このインストーラーは、Aegisub {#BUILD_GIT_VERSION_STRING} を
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "API ベース URL:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "この設定を変更すると問題が発生する可能性があります。"

--- a/po/ja.po
+++ b/po/ja.po
@@ -11832,6 +11832,6 @@ msgstr "このインストーラーは、Aegisub {#BUILD_GIT_VERSION_STRING} を
 msgid "API base URL:"
 msgstr "API ベース URL:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "この設定を変更すると問題が発生する可能性があります。"

--- a/po/ko.po
+++ b/po/ko.po
@@ -12207,3 +12207,7 @@ msgstr "업데이트 확인:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "이제 설치 프로그램이 Aegisub {#BUILD_GIT_VERSION_STRING} 버전을 컴퓨터에 설치합니다.%n%nAegisub 프로그램은 GNU General Public License version 2 라이선스 계약에 따라 보호됩니다. 이는 프로그램을 무료로 사용할 수 있지만, 개발자는 프로그램 작동에 대해 어떠한 보증도 하지 않는다는 의미입니다.%n%n자세한 내용은 Aegisub 웹사이트를 방문하세요. 여기에서 프로그램의 소스 코드도 받을 수 있습니다."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "API 기본 URL:"

--- a/po/ko.po
+++ b/po/ko.po
@@ -12212,6 +12212,6 @@ msgstr "이제 설치 프로그램이 Aegisub {#BUILD_GIT_VERSION_STRING} 버전
 msgid "API base URL:"
 msgstr "API 기본 URL:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "이 설정을 변경하면 문제가 발생할 수 있습니다."

--- a/po/ko.po
+++ b/po/ko.po
@@ -12211,3 +12211,7 @@ msgstr "이제 설치 프로그램이 Aegisub {#BUILD_GIT_VERSION_STRING} 버전
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "API 기본 URL:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "이 설정을 변경하면 문제가 발생할 수 있습니다."

--- a/po/nl.po
+++ b/po/nl.po
@@ -11936,6 +11936,6 @@ msgstr "Het installatieprogramma installeert nu Aegisub versie {#BUILD_GIT_VERSI
 msgid "API base URL:"
 msgstr "Basis-URL van API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Het wijzigen hiervan kan problemen veroorzaken."

--- a/po/nl.po
+++ b/po/nl.po
@@ -11935,3 +11935,7 @@ msgstr "Het installatieprogramma installeert nu Aegisub versie {#BUILD_GIT_VERSI
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "Basis-URL van API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Het wijzigen hiervan kan problemen veroorzaken."

--- a/po/nl.po
+++ b/po/nl.po
@@ -11931,3 +11931,7 @@ msgstr "Controleren op updates:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Het installatieprogramma installeert nu Aegisub versie {#BUILD_GIT_VERSION_STRING} op uw computer.%n%nAegisub valt onder de GNU General Public License version 2. Dit betekent dat u het programma gratis mag gebruiken, maar dat de ontwikkelaars geen enkele garantie bieden voor de werking ervan.%n%nGa voor meer informatie naar de Aegisub-website, waar u onder andere de broncode van het programma kunt downloaden."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "Basis-URL van API:"

--- a/po/pl.po
+++ b/po/pl.po
@@ -11820,3 +11820,7 @@ msgstr "Sprawdzanie aktualizacji:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Instalator zainstaluje teraz na komputerze program Aegisub w wersji {#BUILD_GIT_VERSION_STRING}.%n%nProgram Aegisub jest objęty licencją GNU General Public License version 2. Oznacza to, że można go używać bezpłatnie, jednak twórcy nie udzielają żadnej gwarancji na działanie programu.%n%nWięcej informacji można znaleźć na stronie internetowej Aegisub, z której można również pobrać kod źródłowy programu."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "Bazowy adres URL API:"

--- a/po/pl.po
+++ b/po/pl.po
@@ -11824,3 +11824,7 @@ msgstr "Instalator zainstaluje teraz na komputerze program Aegisub w wersji {#BU
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "Bazowy adres URL API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Zmiana tego ustawienia może powodować problemy."

--- a/po/pl.po
+++ b/po/pl.po
@@ -11825,6 +11825,6 @@ msgstr "Instalator zainstaluje teraz na komputerze program Aegisub w wersji {#BU
 msgid "API base URL:"
 msgstr "Bazowy adres URL API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Zmiana tego ustawienia może powodować problemy."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -12020,3 +12020,7 @@ msgstr "Verificar atualizações:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "O instalador instalará agora a versão {#BUILD_GIT_VERSION_STRING} do Aegisub em seu computador.%n%nO Aegisub é protegido pela licença GNU General Public License versão 2. Isso significa que você pode usar o programa gratuitamente, mas os desenvolvedores não oferecem nenhuma garantia quanto ao funcionamento do programa.%n%nPara obter mais informações, visite o site do Aegisub, onde você também poderá obter o código-fonte do programa."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "URL base da API:"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -12025,6 +12025,6 @@ msgstr "O instalador instalará agora a versão {#BUILD_GIT_VERSION_STRING} do A
 msgid "API base URL:"
 msgstr "URL base da API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Alterar isso pode causar problemas."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -12024,3 +12024,7 @@ msgstr "O instalador instalará agora a versão {#BUILD_GIT_VERSION_STRING} do A
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "URL base da API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Alterar isso pode causar problemas."

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -11998,3 +11998,7 @@ msgstr "Procurar atualizações:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "O instalador irá agora instalar a versão {#BUILD_GIT_VERSION_STRING} do Aegisub no seu computador.%n%nO Aegisub está protegido pela licença GNU General Public License version 2. Isto significa que pode utilizar o programa gratuitamente, mas os seus programadores não oferecem qualquer garantia quanto ao funcionamento do programa.%n%nPara obter mais informações, visite o site do Aegisub, onde poderá, entre outras coisas, obter o código-fonte do programa."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "URL base da API:"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -12002,3 +12002,7 @@ msgstr "O instalador irá agora instalar a versão {#BUILD_GIT_VERSION_STRING} d
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "URL base da API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Alterar isto pode causar problemas."

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -12003,6 +12003,6 @@ msgstr "O instalador irá agora instalar a versão {#BUILD_GIT_VERSION_STRING} d
 msgid "API base URL:"
 msgstr "URL base da API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Alterar isto pode causar problemas."

--- a/po/ru.po
+++ b/po/ru.po
@@ -11897,6 +11897,6 @@ msgstr "Сейчас установщик установит на ваш ком�
 msgid "API base URL:"
 msgstr "Базовый URL API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Изменение этого параметра может вызвать проблемы."

--- a/po/ru.po
+++ b/po/ru.po
@@ -11892,3 +11892,7 @@ msgstr "Проверка обновлений:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Сейчас установщик установит на ваш компьютер Aegisub версии {#BUILD_GIT_VERSION_STRING}.%n%nПрограмма Aegisub распространяется по лицензии GNU General Public License version 2. Это означает, что вы можете бесплатно использовать программу, однако разработчики не предоставляют никаких гарантий её работы.%n%nДля получения дополнительной информации посетите веб-сайт Aegisub, где также можно скачать исходный код программы."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "Базовый URL API:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -11896,3 +11896,7 @@ msgstr "Сейчас установщик установит на ваш ком�
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "Базовый URL API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Изменение этого параметра может вызвать проблемы."

--- a/po/sr_RS.po
+++ b/po/sr_RS.po
@@ -11879,3 +11879,7 @@ msgstr "Провера ажурирања:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Инсталациони програм ће сада инсталирати верзију Aegisub {#BUILD_GIT_VERSION_STRING} на Ваш рачунар.%n%nПрограм Aegisub је заштићен лиценцним уговором GNU General Public License version 2. То значи да програм можете бесплатно користити, али програмери не пружају никакве гаранције за његов рад.%n%nЗа више информација посетите веб-сајт програма Aegisub, где, између осталог, можете преузети изворни код програма."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "Основни URL API-ја:"

--- a/po/sr_RS.po
+++ b/po/sr_RS.po
@@ -11883,3 +11883,7 @@ msgstr "Инсталациони програм ће сада инсталира
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "Основни URL API-ја:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Промена овога може изазвати проблеме."

--- a/po/sr_RS.po
+++ b/po/sr_RS.po
@@ -11884,6 +11884,6 @@ msgstr "Инсталациони програм ће сада инсталира
 msgid "API base URL:"
 msgstr "Основни URL API-ја:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Промена овога може изазвати проблеме."

--- a/po/sr_RS@latin.po
+++ b/po/sr_RS@latin.po
@@ -11883,3 +11883,7 @@ msgstr "Instalacioni program će sada instalirati verziju Aegisub {#BUILD_GIT_VE
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "Osnovni URL API-ja:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Promena ovoga može izazvati probleme."

--- a/po/sr_RS@latin.po
+++ b/po/sr_RS@latin.po
@@ -11884,6 +11884,6 @@ msgstr "Instalacioni program će sada instalirati verziju Aegisub {#BUILD_GIT_VE
 msgid "API base URL:"
 msgstr "Osnovni URL API-ja:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Promena ovoga može izazvati probleme."

--- a/po/sr_RS@latin.po
+++ b/po/sr_RS@latin.po
@@ -11879,3 +11879,7 @@ msgstr "Provera ažuriranja:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Instalacioni program će sada instalirati verziju Aegisub {#BUILD_GIT_VERSION_STRING} na vaš računar.%n%nProgram Aegisub je zaštićen licencom GNU General Public License version 2. To znači da program možete koristiti besplatno, ali programeri ne daju nikakve garancije za njegov rad.%n%nZa više informacija posetite veb-sajt Aegisub-a, gde, između ostalog, možete preuzeti izvorni kôd programa."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "Osnovni URL API-ja:"

--- a/po/tr.po
+++ b/po/tr.po
@@ -12211,6 +12211,6 @@ msgstr "Yükleyici şimdi Aegisub {#BUILD_GIT_VERSION_STRING} sürümünü bilgi
 msgid "API base URL:"
 msgstr "API temel URL'si:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Bunu değiştirmek sorunlara neden olabilir."

--- a/po/tr.po
+++ b/po/tr.po
@@ -12206,3 +12206,7 @@ msgstr "Güncellemeleri denetle:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Yükleyici şimdi Aegisub {#BUILD_GIT_VERSION_STRING} sürümünü bilgisayarınıza yükleyecek.%n%nAegisub programı GNU Genel Kamu Lisansı sürüm 2 lisans sözleşmesiyle korunmaktadır. Bu, programı ücretsiz olarak kullanabileceğiniz, ancak geliştiricilerin programın çalışmasıyla ilgili hiçbir garanti vermediği anlamına gelir.%n%nDaha fazla bilgi için Aegisub web sitesini ziyaret edin; burada programın kaynak kodunu da edinebilirsiniz."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "API temel URL'si:"

--- a/po/tr.po
+++ b/po/tr.po
@@ -12210,3 +12210,7 @@ msgstr "Yükleyici şimdi Aegisub {#BUILD_GIT_VERSION_STRING} sürümünü bilgi
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "API temel URL'si:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Bunu değiştirmek sorunlara neden olabilir."

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -11947,3 +11947,7 @@ msgstr "Перевірка оновлень:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Зараз інсталятор встановить на ваш комп’ютер Aegisub версії {#BUILD_GIT_VERSION_STRING}.%n%nПрограма Aegisub розповсюджується за ліцензією GNU General Public License version 2. Це означає, що ви можете безкоштовно користуватися програмою, але розробники не надають жодних гарантій щодо її роботи.%n%nДокладнішу інформацію можна знайти на вебсайті Aegisub, де також можна отримати вихідний код програми."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "Базова URL-адреса API:"

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -11951,3 +11951,7 @@ msgstr "Зараз інсталятор встановить на ваш ком�
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "Базова URL-адреса API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Зміна цього параметра може спричинити проблеми."

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -11952,6 +11952,6 @@ msgstr "Зараз інсталятор встановить на ваш ком�
 msgid "API base URL:"
 msgstr "Базова URL-адреса API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Зміна цього параметра може спричинити проблеми."

--- a/po/vi.po
+++ b/po/vi.po
@@ -11986,6 +11986,6 @@ msgstr "Trình cài đặt sẽ cài đặt phiên bản Aegisub {#BUILD_GIT_VER
 msgid "API base URL:"
 msgstr "URL cơ sở của API:"
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "Thay đổi mục này có thể gây ra sự cố."

--- a/po/vi.po
+++ b/po/vi.po
@@ -11981,3 +11981,7 @@ msgstr "Kiểm tra cập nhật:"
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "Trình cài đặt sẽ cài đặt phiên bản Aegisub {#BUILD_GIT_VERSION_STRING} vào máy tính của bạn ngay bây giờ.%n%nAegisub được bảo vệ bởi giấy phép GNU General Public License version 2. Điều này có nghĩa là bạn có thể sử dụng chương trình miễn phí, nhưng các nhà phát triển không cung cấp bất kỳ bảo đảm nào về hoạt động của chương trình.%n%nĐể biết thêm thông tin, hãy truy cập trang web Aegisub, nơi bạn cũng có thể tải mã nguồn của chương trình."
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "URL cơ sở của API:"

--- a/po/vi.po
+++ b/po/vi.po
@@ -11985,3 +11985,7 @@ msgstr "Trình cài đặt sẽ cài đặt phiên bản Aegisub {#BUILD_GIT_VER
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "URL cơ sở của API:"
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "Thay đổi mục này có thể gây ra sự cố."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -12103,3 +12103,7 @@ msgstr "安装程序现在将在您的计算机上安装 Aegisub {#BUILD_GIT_VER
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "API 基础 URL："
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "更改此项可能会导致问题。"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -12099,3 +12099,7 @@ msgstr "检查更新："
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "安装程序现在将在您的计算机上安装 Aegisub {#BUILD_GIT_VERSION_STRING} 版本。%n%nAegisub 程序受 GNU General Public License version 2 许可协议保护。这意味着您可以免费使用本程序，但开发者不对程序的运行提供任何保证。%n%n如需了解更多信息，请访问 Aegisub 网站，您还可以在那里获取程序源代码。"
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "API 基础 URL："

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -12104,6 +12104,6 @@ msgstr "安装程序现在将在您的计算机上安装 Aegisub {#BUILD_GIT_VER
 msgid "API base URL:"
 msgstr "API 基础 URL："
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "更改此项可能会导致问题。"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -11866,6 +11866,6 @@ msgstr "安裝程式現在將在您的電腦上安裝 Aegisub {#BUILD_GIT_VERSIO
 msgid "API base URL:"
 msgstr "API 基礎 URL："
 
-#: ../src/dialog_ai_connection.cpp:214
+#: src/dialog_ai_connection.cpp
 msgid "Changing this could cause issues."
 msgstr "變更此項可能會導致問題。"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -11861,3 +11861,7 @@ msgstr "檢查更新："
 #, c-format
 msgid "This will install Aegisub {#BUILD_GIT_VERSION_STRING} on your computer.%n%nAegisub is covered by the GNU General Public License version 2. This means you may use the application for any purpose without charge, but that no warranties of any kind are given either.%n%nSee the Aegisub website for information on obtaining the source code.\\r"
 msgstr "安裝程式現在將在您的電腦上安裝 Aegisub {#BUILD_GIT_VERSION_STRING} 版本。%n%nAegisub 程式受 GNU General Public License version 2 授權條款保護。這表示您可以免費使用本程式，但開發者不對程式的運作提供任何保證。%n%n如需更多資訊，請造訪 Aegisub 網站，您也可以在網站上取得本程式的原始碼。"
+
+#: src/dialog_ai_connection.cpp
+msgid "API base URL:"
+msgstr "API 基礎 URL："

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -11865,3 +11865,7 @@ msgstr "安裝程式現在將在您的電腦上安裝 Aegisub {#BUILD_GIT_VERSIO
 #: src/dialog_ai_connection.cpp
 msgid "API base URL:"
 msgstr "API 基礎 URL："
+
+#: ../src/dialog_ai_connection.cpp:214
+msgid "Changing this could cause issues."
+msgstr "變更此項可能會導致問題。"

--- a/src/ai_client.cpp
+++ b/src/ai_client.cpp
@@ -992,6 +992,10 @@ bool delete_secret_service_secret(char const *account, std::string *message) {
 
 } // namespace
 
+std::string DefaultApiBase() {
+	return default_api_base;
+}
+
 OpenAIClient::OpenAIClient(std::string api_key, std::string model,
 	std::string transcription_model, std::string custom_instructions,
 	std::atomic_bool *cancelled)
@@ -1006,13 +1010,13 @@ OpenAIClient::OpenAIClient(std::string api_key, std::string model,
 }
 
 void OpenAIClient::TestConnection(std::string const& base_url) const {
+	auto const base = normalize_api_base(base_url);
 	CurlHandle curl;
 	std::string response;
 	configure_common(curl, api_key, &response, cancelled);
 	char *escaped = curl_easy_escape(curl, model.c_str(), static_cast<int>(model.size()));
 	if (!escaped) throw Error("A modellnév kódolása sikertelen.");
-	std::string url = (base_url.empty() ? api_base() : normalize_api_base(base_url)) +
-		"/models/" + escaped;
+	std::string url = base + "/models/" + escaped;
 	curl_free(escaped);
 	curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 	auto headers = authenticated_headers(api_key, false);

--- a/src/ai_client.cpp
+++ b/src/ai_client.cpp
@@ -37,7 +37,18 @@
 namespace ai {
 namespace {
 
-constexpr char api_base[] = "https://api.openai.com/v1";
+constexpr char default_api_base[] = "https://api.openai.com/v1";
+
+std::string normalize_api_base(std::string base) {
+	if (base.empty()) base = default_api_base;
+	while (base.size() > 1 && base.back() == '/')
+		base.pop_back();
+	return base;
+}
+
+std::string api_base() {
+	return normalize_api_base(OPT_GET("AI/OpenAI/Base URL")->GetString());
+}
 constexpr size_t proofread_max_input_chars = 900000;
 constexpr size_t proofread_max_lines_per_request = 300;
 #ifdef _WIN32
@@ -759,7 +770,7 @@ ReviewResult structured_request(std::string const& key,
 	request["store"] = false;
 	request["max_output_tokens"] = include_line_reviews ? 12000 : 4000;
 
-	auto response_text = post_json(key, std::string(api_base) + "/responses",
+	auto response_text = post_json(key, api_base() + "/responses",
 		write_json(request), cancelled);
 	auto response_root_value = parse_json(response_text);
 	auto& response_root = static_cast<json::Object&>(response_root_value);
@@ -798,7 +809,7 @@ ProofreadResult proofread_request(std::string const& key,
 	request["store"] = false;
 	request["max_output_tokens"] = 16000;
 
-	auto response_text = post_json(key, std::string(api_base) + "/responses",
+	auto response_text = post_json(key, api_base() + "/responses",
 		write_json(request), cancelled);
 	auto response_root_value = parse_json(response_text);
 	auto const& response_root = static_cast<json::Object const&>(response_root_value);
@@ -961,13 +972,14 @@ OpenAIClient::OpenAIClient(std::string api_key, std::string model,
 	if (this->transcription_model.empty()) throw Error("Nincs beállítva beszédfelismerési modell.");
 }
 
-void OpenAIClient::TestConnection() const {
+void OpenAIClient::TestConnection(std::string const& base_url) const {
 	CurlHandle curl;
 	std::string response;
 	configure_common(curl, api_key, &response, cancelled);
 	char *escaped = curl_easy_escape(curl, model.c_str(), static_cast<int>(model.size()));
 	if (!escaped) throw Error("A modellnév kódolása sikertelen.");
-	std::string url = std::string(api_base) + "/models/" + escaped;
+	std::string url = (base_url.empty() ? api_base() : normalize_api_base(base_url)) +
+		"/models/" + escaped;
 	curl_free(escaped);
 	curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 	auto headers = authenticated_headers(api_key, false);
@@ -978,7 +990,7 @@ std::string OpenAIClient::Transcribe(agi::fs::path const& audio_file) const {
 	CurlHandle curl;
 	std::string response;
 	configure_common(curl, api_key, &response, cancelled);
-	curl_easy_setopt(curl, CURLOPT_URL, (std::string(api_base) + "/audio/transcriptions").c_str());
+	curl_easy_setopt(curl, CURLOPT_URL, (api_base() + "/audio/transcriptions").c_str());
 
 	curl_mime *mime = curl_mime_init(curl);
 	if (!mime) throw Error("A hangfeltöltés előkészítése sikertelen.");
@@ -1033,7 +1045,7 @@ std::string EditImage(std::string const& api_key, std::string const& image_model
 	std::string response;
 	std::function<bool()> cancel_check = is_cancelled;
 	configure_common(curl, api_key, &response, nullptr);
-	curl_easy_setopt(curl, CURLOPT_URL, (std::string(api_base) + "/images/edits").c_str());
+	curl_easy_setopt(curl, CURLOPT_URL, (api_base() + "/images/edits").c_str());
 
 	curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, function_progress_callback);
 	curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &cancel_check);
@@ -1098,7 +1110,7 @@ TimedTranscript OpenAIClient::TranscribeTimed(agi::fs::path const& audio_file) c
 	CurlHandle curl;
 	std::string response;
 	configure_common(curl, api_key, &response, cancelled);
-	curl_easy_setopt(curl, CURLOPT_URL, (std::string(api_base) + "/audio/transcriptions").c_str());
+	curl_easy_setopt(curl, CURLOPT_URL, (api_base() + "/audio/transcriptions").c_str());
 
 	curl_mime *mime = curl_mime_init(curl);
 	if (!mime) throw Error("A hangfeltöltés előkészítése sikertelen.");
@@ -1239,7 +1251,7 @@ KaraokeResult OpenAIClient::CreateKaraoke(KaraokeMode mode,
 	request["reasoning"] = std::move(reasoning);
 	request["store"] = false;
 	request["max_output_tokens"] = 16000;
-	auto response_text = post_json(api_key, std::string(api_base) + "/responses",
+	auto response_text = post_json(api_key, api_base() + "/responses",
 		write_json(request), cancelled);
 	auto response_root_value = parse_json(response_text);
 	auto const& response_root = static_cast<json::Object const&>(response_root_value);
@@ -1288,7 +1300,7 @@ KaraokeResult OpenAIClient::CreateKanji(std::vector<KaraokeInputLine> const& lin
 	request["reasoning"] = std::move(reasoning);
 	request["store"] = false;
 	request["max_output_tokens"] = 8000;
-	auto response_text = post_json(api_key, std::string(api_base) + "/responses",
+	auto response_text = post_json(api_key, api_base() + "/responses",
 		write_json(request), cancelled);
 	auto response_root_value = parse_json(response_text);
 	auto const& response_root = static_cast<json::Object const&>(response_root_value);

--- a/src/ai_client.cpp
+++ b/src/ai_client.cpp
@@ -15,6 +15,7 @@
 #include <wx/base64.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstring>
 #include <cstdlib>
@@ -39,8 +40,30 @@ namespace {
 
 constexpr char default_api_base[] = "https://api.openai.com/v1";
 
+bool has_scheme(std::string const& url, char const *scheme) {
+	auto const length = std::strlen(scheme);
+	return url.size() >= length &&
+		std::equal(scheme, scheme + length, url.begin(), [](char a, char b) {
+			return a == std::tolower(static_cast<unsigned char>(b));
+		});
+}
+
 std::string normalize_api_base(std::string base) {
+	auto const first = base.find_first_not_of(" \t\r\n");
+	if (first == std::string::npos)
+		base.clear();
+	else
+		base = base.substr(first, base.find_last_not_of(" \t\r\n") - first + 1);
+
 	if (base.empty()) base = default_api_base;
+
+	// The API key travels to this address in an Authorization header, so assume
+	// TLS when the user leaves the scheme out and refuse anything but HTTP(S).
+	if (base.find("://") == std::string::npos)
+		base.insert(0, "https://");
+	else if (!has_scheme(base, "http://") && !has_scheme(base, "https://"))
+		throw Error("Az API alapcímének http:// vagy https:// protokollt kell használnia.");
+
 	while (base.size() > 1 && base.back() == '/')
 		base.pop_back();
 	return base;
@@ -49,6 +72,7 @@ std::string normalize_api_base(std::string base) {
 std::string api_base() {
 	return normalize_api_base(OPT_GET("AI/OpenAI/Base URL")->GetString());
 }
+
 constexpr size_t proofread_max_input_chars = 900000;
 constexpr size_t proofread_max_lines_per_request = 300;
 #ifdef _WIN32
@@ -129,6 +153,15 @@ public:
 void configure_common(CURL *curl, std::string const& api_key,
 	std::string *response, std::atomic_bool *cancelled) {
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+	// The API base URL is user-configurable, so keep transfers on HTTP(S)
+	// instead of letting curl pick a protocol out of the configured address.
+#if LIBCURL_VERSION_NUM >= 0x075500
+	curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "http,https");
+	curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
+#else
+	curl_easy_setopt(curl, CURLOPT_PROTOCOLS, static_cast<long>(CURLPROTO_HTTP | CURLPROTO_HTTPS));
+	curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, static_cast<long>(CURLPROTO_HTTP | CURLPROTO_HTTPS));
+#endif
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, "Aegisub-Muteki/AI");
 	// Long transcription and review requests have no client-side time limit.
 	// They remain cancellable through the transfer callback below.

--- a/src/ai_client.h
+++ b/src/ai_client.h
@@ -118,7 +118,7 @@ public:
 		std::string transcription_model, std::string custom_instructions = {},
 		std::atomic_bool *cancelled = nullptr);
 
-	void TestConnection() const;
+	void TestConnection(std::string const& base_url = {}) const;
 	std::string Transcribe(agi::fs::path const& audio_file) const;
 	TimedTranscript TranscribeTimed(agi::fs::path const& audio_file) const;
 	KaraokeResult CreateKaraoke(KaraokeMode mode,

--- a/src/ai_client.h
+++ b/src/ai_client.h
@@ -106,6 +106,9 @@ struct ReviewResult {
 	std::string conversation_json = "[]";
 };
 
+/// The API base URL used when nothing is configured.
+std::string DefaultApiBase();
+
 class OpenAIClient final {
 	std::string api_key;
 	std::string model;
@@ -118,7 +121,9 @@ public:
 		std::string transcription_model, std::string custom_instructions = {},
 		std::atomic_bool *cancelled = nullptr);
 
-	void TestConnection(std::string const& base_url = {}) const;
+	/// Test the connection against the given base URL. An empty value means
+	/// DefaultApiBase().
+	void TestConnection(std::string const& base_url) const;
 	std::string Transcribe(agi::fs::path const& audio_file) const;
 	TimedTranscript TranscribeTimed(agi::fs::path const& audio_file) const;
 	KaraokeResult CreateKaraoke(KaraokeMode mode,

--- a/src/dialog_ai_connection.cpp
+++ b/src/dialog_ai_connection.cpp
@@ -209,6 +209,7 @@ public:
 		openai_form->Add(new wxStaticText(this, wxID_ANY, _("API base URL:")), 0, wxALIGN_CENTER_VERTICAL);
 		api_base_url = new wxTextCtrl(this, wxID_ANY,
 			to_wx(OPT_GET("AI/OpenAI/Base URL")->GetString()));
+		api_base_url->SetHint(to_wx(ai::DefaultApiBase()));
 		openai_form->Add(api_base_url, wxSizerFlags(1).Expand());
 		openai_form->AddSpacer(0);
 		auto api_base_warning = new wxStaticText(this, wxID_ANY, _("Changing this could cause issues."));

--- a/src/dialog_ai_connection.cpp
+++ b/src/dialog_ai_connection.cpp
@@ -24,6 +24,7 @@ namespace {
 
 class AIConnectionDialog final : public wxDialog {
 	wxTextCtrl *openai_key;
+	wxTextCtrl *api_base_url;
 	wxTextCtrl *model;
 	wxTextCtrl *image_model;
 	wxCheckBox *remember_openai;
@@ -86,7 +87,7 @@ class AIConnectionDialog final : public wxDialog {
 		try {
 			ai::OpenAIClient client(key, from_wx(model->GetValue()),
 				"gpt-transcribe");
-			client.TestConnection();
+			client.TestConnection(from_wx(api_base_url->GetValue()));
 			wxMessageBox(_("The OpenAI connection is working."), _("AI connection"),
 				wxOK | wxICON_INFORMATION, this);
 		}
@@ -172,6 +173,7 @@ class AIConnectionDialog final : public wxDialog {
 			return;
 		}
 
+		OPT_SET("AI/OpenAI/Base URL")->SetString(from_wx(api_base_url->GetValue()));
 		OPT_SET("AI/OpenAI/Model")->SetString(from_wx(model->GetValue()));
 		OPT_SET("AI/OpenAI/Image Model")->SetString(from_wx(image_model->GetValue()));
 		OPT_SET("AI/Cloudinary/Cloud Name")->SetString(from_wx(cloud_name->GetValue()));
@@ -204,6 +206,10 @@ public:
 		openai_key = new wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxTE_PASSWORD);
 		openai_key->SetHint(_("Leave empty to keep using the current key"));
 		openai_form->Add(openai_key, wxSizerFlags(1).Expand());
+		openai_form->Add(new wxStaticText(this, wxID_ANY, _("API base URL:")), 0, wxALIGN_CENTER_VERTICAL);
+		api_base_url = new wxTextCtrl(this, wxID_ANY,
+			to_wx(OPT_GET("AI/OpenAI/Base URL")->GetString()));
+		openai_form->Add(api_base_url, wxSizerFlags(1).Expand());
 		openai_form->Add(new wxStaticText(this, wxID_ANY, _("AI model:")), 0, wxALIGN_CENTER_VERTICAL);
 		model = new wxTextCtrl(this, wxID_ANY, to_wx(OPT_GET("AI/OpenAI/Model")->GetString()));
 		openai_form->Add(model, wxSizerFlags(1).Expand());

--- a/src/dialog_ai_connection.cpp
+++ b/src/dialog_ai_connection.cpp
@@ -210,6 +210,9 @@ public:
 		api_base_url = new wxTextCtrl(this, wxID_ANY,
 			to_wx(OPT_GET("AI/OpenAI/Base URL")->GetString()));
 		openai_form->Add(api_base_url, wxSizerFlags(1).Expand());
+		openai_form->AddSpacer(0);
+		auto api_base_warning = new wxStaticText(this, wxID_ANY, _("Changing this could cause issues."));
+		openai_form->Add(api_base_warning, wxSizerFlags(1).Expand());
 		openai_form->Add(new wxStaticText(this, wxID_ANY, _("AI model:")), 0, wxALIGN_CENTER_VERTICAL);
 		model = new wxTextCtrl(this, wxID_ANY, to_wx(OPT_GET("AI/OpenAI/Model")->GetString()));
 		openai_form->Add(model, wxSizerFlags(1).Expand());

--- a/src/dialog_ai_connection.cpp
+++ b/src/dialog_ai_connection.cpp
@@ -213,6 +213,7 @@ public:
 		openai_form->Add(api_base_url, wxSizerFlags(1).Expand());
 		openai_form->AddSpacer(0);
 		auto api_base_warning = new wxStaticText(this, wxID_ANY, _("Changing this could cause issues."));
+		api_base_warning->Wrap(360);
 		openai_form->Add(api_base_warning, wxSizerFlags(1).Expand());
 		openai_form->Add(new wxStaticText(this, wxID_ANY, _("AI model:")), 0, wxALIGN_CENTER_VERTICAL);
 		model = new wxTextCtrl(this, wxID_ANY, to_wx(OPT_GET("AI/OpenAI/Model")->GetString()));

--- a/src/libresrc/default_config.json
+++ b/src/libresrc/default_config.json
@@ -105,6 +105,7 @@
 			"Cloud Name" : ""
 		},
 		"OpenAI" : {
+			"Base URL" : "https://api.openai.com/v1",
 			"Image Model" : "gpt-image-2",
 			"Model" : "gpt-5.6-terra"
 		}


### PR DESCRIPTION
Adds a configurable OpenAI API base URL in the AI connection settings, while keeping the official OpenAI endpoint as the default. The configured URL is used for text, transcription, image editing, and connection tests.

Off-topic: would you consider enabling Issues? It might make bug reports and feedback a bit easier.